### PR TITLE
fix: boolean parsing

### DIFF
--- a/pg_replicate/src/conversions/cdc_event.rs
+++ b/pg_replicate/src/conversions/cdc_event.rs
@@ -83,7 +83,7 @@ impl CdcEventConverter {
                 let val = match val {
                     "t" => true,
                     "f" => false,
-                    other => val.parse()?
+                    _ => val.parse()?
                 };
                 Ok(Cell::Bool(val))
             }

--- a/pg_replicate/src/conversions/cdc_event.rs
+++ b/pg_replicate/src/conversions/cdc_event.rs
@@ -80,7 +80,11 @@ impl CdcEventConverter {
         match *typ {
             Type::BOOL => {
                 let val = from_utf8(bytes)?;
-                let val: bool = val.parse()?;
+                let val = match val {
+                    "t" => true,
+                    "f" => false,
+                    other => val.parse()?
+                };
                 Ok(Cell::Bool(val))
             }
             // Type::BYTEA => Ok(Value::Bytes(bytes.to_vec())),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for boolean value parsing.

## What is the current behavior?

I did not create an issue beforehand, so I will describe the current behavior here. 
I am running PostgreSQL 17 (`PostgreSQL 17.0 (Debian 17.0-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit`). 
With the following table:
```sql
-- create a table
CREATE TABLE test(
  id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
  name TEXT NOT NULL,
  archived BOOLEAN NOT NULL DEFAULT FALSE
);

-- add test data
INSERT INTO test (name, archived)
  VALUES ('test row 1', true),
  ('test row 2', false);
```

I created the publication like so:
```sql
create publication my_publication for table test;
```

and later I ran the `stdout` example.

I ran the following query:
```sql
update test set name='test row 1' where id=1;
```

which resulted in `SourceError(CdcStream(CdcEventConversion(InvalidBool(ParseBoolError))))`

## What is the new behavior?

I changed slightly the boolean parsing so that `t` and `f` are parsed correctly.
