### PR TITLE
fix: set pipeline resumption state props public

### DIFF
--- a/pg_replicate/src/pipeline/mod.rs
+++ b/pg_replicate/src/pipeline/mod.rs
@@ -29,6 +29,6 @@ pub enum PipelineError {
 }
 
 pub struct PipelineResumptionState {
-    copied_tables: HashSet<TableId>,
-    last_lsn: PgLsn,
+    pub copied_tables: HashSet<TableId>,
+    pub last_lsn: PgLsn,
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix see #62 


## What is the new behavior?

`PipelineResumptionState` properties are made public

## Additional context

Right now visibility of properties of `PipelineResumptionState` is set to private. This prevents using `pg_replicate` as a library when using custom sinks
