### PR TITLE
fix: syntax error when getting column schemas

### DIFF
--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -137,7 +137,7 @@ impl ReplicationClient {
                 a.atttypid,
                 a.atttypmod,
                 a.attnotnull,
-                coalesce(i.indisprimary, false) primary
+                coalesce(i.indisprimary, false) as primary
             from pg_attribute a
             left join pg_index i
                 on a.attrelid = i.indrelid


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes a syntax error. In earlier versions of pg, looks like a syntax error is thrown when using the `primary` keyword as an alias implicitly
![image](https://github.com/user-attachments/assets/1e377d24-eee7-4158-8877-224081f941fe)

Works when you explicitly put `as`:
![image](https://github.com/user-attachments/assets/21002f83-d11d-415e-af0a-9552a9e31a20)

