### PR TITLE
fix: retrieve distinct columns

### DIFF
--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -133,7 +133,7 @@ impl ReplicationClient {
         table_id: TableId,
     ) -> Result<Vec<ColumnSchema>, ReplicationClientError> {
         let column_info_query = format!(
-            "select a.attname,
+            "select distinct a.attname,
                 a.atttypid,
                 a.atttypmod,
                 a.attnotnull,


### PR DESCRIPTION
## What kind of change does this PR introduce?

In cases where a column name is used included in multiple indexes on a table, the join between pg_attribute and pg_index will return a row for each index involving that column. Fix here is to select distinct columns in order to avoid duplicate column names on table creation in the sink.

## What is the current behavior?

duplicate columns in sink table creation
![image](https://github.com/user-attachments/assets/a48b2ceb-a075-4ac9-bd9c-c0e77b74c17f)

## What is the new behavior?

select unique column names

## Additional context

N/A