### PR TITLE
Make sinks, sources, and pipelines generic on their errors

### DIFF
--- a/pg_replicate/src/pipeline/batching/data_pipeline.rs
+++ b/pg_replicate/src/pipeline/batching/data_pipeline.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, time::Instant};
 use futures::StreamExt;
 use tokio::pin;
 use tokio_postgres::types::PgLsn;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::{
     conversions::cdc_event::{CdcEvent, CdcEventConversionError},

--- a/pg_replicate/src/pipeline/batching/data_pipeline.rs
+++ b/pg_replicate/src/pipeline/batching/data_pipeline.rs
@@ -84,8 +84,13 @@ impl<Src: Source, Snk: BatchSink> BatchDataPipeline<Src, Snk> {
 
             while let Some(batch) = batch_timeout_stream.next().await {
                 info!("got {} table copy events in a batch", batch.len());
+                //TODO: Avoid a vec copy
+                let mut rows = Vec::with_capacity(batch.len());
+                for row in batch {
+                    rows.push(row.map_err(CommonSourceError::TableCopyStream)?);
+                }
                 self.sink
-                    .write_table_rows(batch, table_schema.table_id)
+                    .write_table_rows(rows, table_schema.table_id)
                     .await
                     .map_err(PipelineError::Sink)?;
             }

--- a/pg_replicate/src/pipeline/mod.rs
+++ b/pg_replicate/src/pipeline/mod.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
 
+use sinks::SinkError;
+use sources::SourceError;
 use thiserror::Error;
 use tokio_postgres::types::PgLsn;
 
 use crate::table::TableId;
-
-use self::{sinks::SinkError, sources::SourceError};
 
 pub mod batching;
 pub mod data_pipeline;
@@ -19,16 +19,19 @@ pub enum PipelineAction {
     Both,
 }
 
-#[derive(Debug, Error)]
-pub enum PipelineError {
-    #[error("source error: {0}")]
-    SourceError(#[from] SourceError),
-
-    #[error("sink error: {0}")]
-    SinkError(#[from] SinkError),
-}
-
 pub struct PipelineResumptionState {
     pub copied_tables: HashSet<TableId>,
     pub last_lsn: PgLsn,
+}
+
+#[derive(Debug, Error)]
+pub enum PipelineError<SrcErr: SourceError, SnkErr: SinkError> {
+    #[error("source error: {0}")]
+    Source(#[source] SrcErr),
+
+    #[error("sink error: {0}")]
+    Sink(#[source] SnkErr),
+
+    #[error("source error: {0}")]
+    CommonSource(#[from] sources::CommonSourceError),
 }

--- a/pg_replicate/src/pipeline/sinks/bigquery.rs
+++ b/pg_replicate/src/pipeline/sinks/bigquery.rs
@@ -9,7 +9,7 @@ use tracing::info;
 use crate::{
     clients::bigquery::BigQueryClient,
     conversions::{cdc_event::CdcEvent, table_row::TableRow, Cell},
-    pipeline::{sources::postgres::TableCopyStreamError, PipelineResumptionState},
+    pipeline::PipelineResumptionState,
     table::{ColumnSchema, TableId, TableName, TableSchema},
 };
 
@@ -162,24 +162,19 @@ impl BatchSink for BigQueryBatchSink {
 
     async fn write_table_rows(
         &mut self,
-        mut table_rows: Vec<Result<TableRow, TableCopyStreamError>>,
+        mut table_rows: Vec<TableRow>,
         table_id: TableId,
     ) -> Result<(), Self::Error> {
         let table_schema = self.get_table_schema(table_id)?;
         let table_name = Self::table_name_in_bq(&table_schema.table_name);
         let table_descriptor = table_schema.into();
 
-        let new_rows = table_rows
-            .drain(..)
-            .filter_map(|row| row.ok())
-            .map(|mut row| {
-                row.values.push(Cell::String("UPSERT".to_string()));
-                row
-            })
-            .collect::<Vec<TableRow>>();
+        for table_row in &mut table_rows {
+            table_row.values.push(Cell::String("UPSERT".to_string()));
+        }
 
         self.client
-            .stream_rows(&self.dataset_id, table_name, &table_descriptor, &new_rows)
+            .stream_rows(&self.dataset_id, table_name, &table_descriptor, &table_rows)
             .await?;
 
         Ok(())

--- a/pg_replicate/src/pipeline/sinks/bigquery.rs
+++ b/pg_replicate/src/pipeline/sinks/bigquery.rs
@@ -9,7 +9,7 @@ use tracing::info;
 use crate::{
     clients::bigquery::BigQueryClient,
     conversions::{cdc_event::CdcEvent, table_row::TableRow, Cell},
-    pipeline::{PipelineResumptionState, sources::postgres::TableCopyStreamError},
+    pipeline::{sources::postgres::TableCopyStreamError, PipelineResumptionState},
     table::{ColumnSchema, TableId, TableName, TableSchema},
 };
 

--- a/pg_replicate/src/pipeline/sinks/duckdb/mod.rs
+++ b/pg_replicate/src/pipeline/sinks/duckdb/mod.rs
@@ -1,7 +1,7 @@
 pub use executor::{DuckDbExecutorError, DuckDbRequest};
 pub use sink::DuckDbSink;
 
-use super::{Sink, SinkError};
+use super::Sink;
 
 mod executor;
 mod sink;

--- a/pg_replicate/src/pipeline/sinks/mod.rs
+++ b/pg_replicate/src/pipeline/sinks/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     table::{TableId, TableSchema},
 };
 
-use super::{sources::postgres::TableCopyStreamError, PipelineResumptionState};
+use super::PipelineResumptionState;
 
 #[cfg(feature = "bigquery")]
 pub mod bigquery;
@@ -53,7 +53,7 @@ pub trait BatchSink {
     ) -> Result<(), Self::Error>;
     async fn write_table_rows(
         &mut self,
-        rows: Vec<Result<TableRow, TableCopyStreamError>>,
+        rows: Vec<TableRow>,
         table_id: TableId,
     ) -> Result<(), Self::Error>;
     async fn write_cdc_events(&mut self, events: Vec<CdcEvent>) -> Result<PgLsn, Self::Error>;

--- a/pg_replicate/src/pipeline/sinks/mod.rs
+++ b/pg_replicate/src/pipeline/sinks/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use thiserror::Error;
 use tokio_postgres::types::PgLsn;
 
 use crate::{
@@ -18,6 +19,11 @@ pub mod duckdb;
 pub mod stdout;
 
 pub trait SinkError: std::error::Error + Send + Sync + 'static {}
+
+#[derive(Debug, Error)]
+#[error("unreachable")]
+pub enum InfallibleSinkError {}
+impl SinkError for InfallibleSinkError {}
 
 #[async_trait]
 pub trait Sink {

--- a/pg_replicate/src/pipeline/sinks/mod.rs
+++ b/pg_replicate/src/pipeline/sinks/mod.rs
@@ -1,15 +1,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-#[cfg(feature = "bigquery")]
-use gcp_bigquery_client::error::BQError;
-use thiserror::Error;
-#[cfg(feature = "duckdb")]
-use tokio::sync::mpsc::error::SendError;
 use tokio_postgres::types::PgLsn;
-
-#[cfg(feature = "bigquery")]
-use bigquery::BigQuerySinkError;
 
 use crate::{
     conversions::{cdc_event::CdcEvent, table_row::TableRow},
@@ -18,9 +10,6 @@ use crate::{
 
 use super::PipelineResumptionState;
 
-#[cfg(feature = "duckdb")]
-use self::duckdb::{DuckDbExecutorError, DuckDbRequest};
-
 #[cfg(feature = "bigquery")]
 pub mod bigquery;
 #[cfg(feature = "duckdb")]
@@ -28,55 +17,40 @@ pub mod duckdb;
 #[cfg(feature = "stdout")]
 pub mod stdout;
 
-#[derive(Debug, Error)]
-pub enum SinkError {
-    #[cfg(feature = "duckdb")]
-    #[error("failed to send duckdb request")]
-    SendError(#[from] SendError<DuckDbRequest>),
-
-    #[cfg(feature = "duckdb")]
-    #[error("duckdb executor error: {0}")]
-    DuckDbExecutor(#[from] DuckDbExecutorError),
-
-    #[error("no response received")]
-    NoResponseReceived,
-
-    #[cfg(feature = "bigquery")]
-    #[error("bigquery sink error: {0}")]
-    BigQuerySink(#[from] BigQuerySinkError),
-
-    //TODO: remove and use the one wrapped inside BigQuerySinkError
-    #[cfg(feature = "bigquery")]
-    #[error("bigquery error: {0}")]
-    BigQuery(#[from] BQError),
-}
+pub trait SinkError: std::error::Error + Send + Sync + 'static {}
 
 #[async_trait]
 pub trait Sink {
-    async fn get_resumption_state(&mut self) -> Result<PipelineResumptionState, SinkError>;
+    type Error: SinkError;
+    async fn get_resumption_state(&mut self) -> Result<PipelineResumptionState, Self::Error>;
     async fn write_table_schemas(
         &mut self,
         table_schemas: HashMap<TableId, TableSchema>,
-    ) -> Result<(), SinkError>;
-    async fn write_table_row(&mut self, row: TableRow, table_id: TableId) -> Result<(), SinkError>;
-    async fn write_cdc_event(&mut self, event: CdcEvent) -> Result<PgLsn, SinkError>;
-    async fn table_copied(&mut self, table_id: TableId) -> Result<(), SinkError>;
-    async fn truncate_table(&mut self, table_id: TableId) -> Result<(), SinkError>;
+    ) -> Result<(), Self::Error>;
+    async fn write_table_row(
+        &mut self,
+        row: TableRow,
+        table_id: TableId,
+    ) -> Result<(), Self::Error>;
+    async fn write_cdc_event(&mut self, event: CdcEvent) -> Result<PgLsn, Self::Error>;
+    async fn table_copied(&mut self, table_id: TableId) -> Result<(), Self::Error>;
+    async fn truncate_table(&mut self, table_id: TableId) -> Result<(), Self::Error>;
 }
 
 #[async_trait]
 pub trait BatchSink {
-    async fn get_resumption_state(&mut self) -> Result<PipelineResumptionState, SinkError>;
+    type Error: SinkError;
+    async fn get_resumption_state(&mut self) -> Result<PipelineResumptionState, Self::Error>;
     async fn write_table_schemas(
         &mut self,
         table_schemas: HashMap<TableId, TableSchema>,
-    ) -> Result<(), SinkError>;
+    ) -> Result<(), Self::Error>;
     async fn write_table_rows(
         &mut self,
         rows: Vec<TableRow>,
         table_id: TableId,
-    ) -> Result<(), SinkError>;
-    async fn write_cdc_events(&mut self, events: Vec<CdcEvent>) -> Result<PgLsn, SinkError>;
-    async fn table_copied(&mut self, table_id: TableId) -> Result<(), SinkError>;
-    async fn truncate_table(&mut self, table_id: TableId) -> Result<(), SinkError>;
+    ) -> Result<(), Self::Error>;
+    async fn write_cdc_events(&mut self, events: Vec<CdcEvent>) -> Result<PgLsn, Self::Error>;
+    async fn table_copied(&mut self, table_id: TableId) -> Result<(), Self::Error>;
+    async fn truncate_table(&mut self, table_id: TableId) -> Result<(), Self::Error>;
 }

--- a/pg_replicate/src/pipeline/sinks/mod.rs
+++ b/pg_replicate/src/pipeline/sinks/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     table::{TableId, TableSchema},
 };
 
-use super::PipelineResumptionState;
+use super::{sources::postgres::TableCopyStreamError, PipelineResumptionState};
 
 #[cfg(feature = "bigquery")]
 pub mod bigquery;
@@ -53,7 +53,7 @@ pub trait BatchSink {
     ) -> Result<(), Self::Error>;
     async fn write_table_rows(
         &mut self,
-        rows: Vec<TableRow>,
+        rows: Vec<Result<TableRow, TableCopyStreamError>>,
         table_id: TableId,
     ) -> Result<(), Self::Error>;
     async fn write_cdc_events(&mut self, events: Vec<CdcEvent>) -> Result<PgLsn, Self::Error>;

--- a/pg_replicate/src/pipeline/sinks/stdout.rs
+++ b/pg_replicate/src/pipeline/sinks/stdout.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    convert::Infallible,
-};
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use tokio_postgres::types::PgLsn;
@@ -13,15 +10,13 @@ use crate::{
     table::{TableId, TableSchema},
 };
 
-use super::{Sink, SinkError};
+use super::{Sink, SinkError, InfallibleSinkError};
 
 pub struct StdoutSink;
 
-impl SinkError for Infallible {}
-
 #[async_trait]
 impl Sink for StdoutSink {
-    type Error = Infallible;
+    type Error = InfallibleSinkError;
     async fn get_resumption_state(&mut self) -> Result<PipelineResumptionState, Self::Error> {
         Ok(PipelineResumptionState {
             copied_tables: HashSet::new(),

--- a/pg_replicate/src/pipeline/sinks/stdout.rs
+++ b/pg_replicate/src/pipeline/sinks/stdout.rs
@@ -10,7 +10,7 @@ use crate::{
     table::{TableId, TableSchema},
 };
 
-use super::{Sink, SinkError, InfallibleSinkError};
+use super::{InfallibleSinkError, Sink, SinkError};
 
 pub struct StdoutSink;
 

--- a/pg_replicate/src/pipeline/sinks/stdout.rs
+++ b/pg_replicate/src/pipeline/sinks/stdout.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::Infallible,
+};
 
 use async_trait::async_trait;
 use tokio_postgres::types::PgLsn;
@@ -14,9 +17,12 @@ use super::{Sink, SinkError};
 
 pub struct StdoutSink;
 
+impl SinkError for Infallible {}
+
 #[async_trait]
 impl Sink for StdoutSink {
-    async fn get_resumption_state(&mut self) -> Result<PipelineResumptionState, SinkError> {
+    type Error = Infallible;
+    async fn get_resumption_state(&mut self) -> Result<PipelineResumptionState, Self::Error> {
         Ok(PipelineResumptionState {
             copied_tables: HashSet::new(),
             last_lsn: PgLsn::from(0),
@@ -26,7 +32,7 @@ impl Sink for StdoutSink {
     async fn write_table_schemas(
         &mut self,
         table_schemas: HashMap<TableId, TableSchema>,
-    ) -> Result<(), SinkError> {
+    ) -> Result<(), Self::Error> {
         info!("{table_schemas:?}");
         Ok(())
     }
@@ -35,22 +41,22 @@ impl Sink for StdoutSink {
         &mut self,
         row: TableRow,
         _table_id: TableId,
-    ) -> Result<(), SinkError> {
+    ) -> Result<(), Self::Error> {
         info!("{row:?}");
         Ok(())
     }
 
-    async fn write_cdc_event(&mut self, event: CdcEvent) -> Result<PgLsn, SinkError> {
+    async fn write_cdc_event(&mut self, event: CdcEvent) -> Result<PgLsn, Self::Error> {
         info!("{event:?}");
         Ok(PgLsn::from(0))
     }
 
-    async fn table_copied(&mut self, table_id: TableId) -> Result<(), SinkError> {
+    async fn table_copied(&mut self, table_id: TableId) -> Result<(), Self::Error> {
         info!("table {table_id} copied");
         Ok(())
     }
 
-    async fn truncate_table(&mut self, table_id: TableId) -> Result<(), SinkError> {
+    async fn truncate_table(&mut self, table_id: TableId) -> Result<(), Self::Error> {
         info!("table {table_id} truncated");
         Ok(())
     }

--- a/pg_replicate/src/pipeline/sources/mod.rs
+++ b/pg_replicate/src/pipeline/sources/mod.rs
@@ -16,6 +16,11 @@ pub mod postgres;
 pub trait SourceError: std::error::Error + Send + Sync + 'static {}
 
 #[derive(Debug, Error)]
+#[error("unreachable")]
+pub enum InfallibleSourceError {}
+impl SourceError for InfallibleSourceError {}
+
+#[derive(Debug, Error)]
 pub enum CommonSourceError {
     #[error("source error: {0}")]
     Postgres(#[from] PostgresSourceError),

--- a/pg_replicate/src/pipeline/sources/mod.rs
+++ b/pg_replicate/src/pipeline/sources/mod.rs
@@ -13,8 +13,10 @@ use self::postgres::{
 
 pub mod postgres;
 
+pub trait SourceError: std::error::Error + Send + Sync + 'static {}
+
 #[derive(Debug, Error)]
-pub enum SourceError {
+pub enum CommonSourceError {
     #[error("source error: {0}")]
     Postgres(#[from] PostgresSourceError),
 
@@ -28,17 +30,21 @@ pub enum SourceError {
     StatusUpdate(#[from] StatusUpdateError),
 }
 
+impl SourceError for CommonSourceError {}
+
 #[async_trait]
 pub trait Source {
+    type Error: SourceError;
+
     fn get_table_schemas(&self) -> &HashMap<TableId, TableSchema>;
 
     async fn get_table_copy_stream(
         &self,
         table_name: &TableName,
         column_schemas: &[ColumnSchema],
-    ) -> Result<TableCopyStream, SourceError>;
+    ) -> Result<TableCopyStream, Self::Error>;
 
-    async fn commit_transaction(&self) -> Result<(), SourceError>;
+    async fn commit_transaction(&self) -> Result<(), Self::Error>;
 
-    async fn get_cdc_stream(&self, start_lsn: PgLsn) -> Result<CdcStream, SourceError>;
+    async fn get_cdc_stream(&self, start_lsn: PgLsn) -> Result<CdcStream, Self::Error>;
 }


### PR DESCRIPTION
Implementation of #29.

- `PipelineError` becomes generic: `PipelineError<SrcErr: SourceError, SnkErr: SinkError>`
- We introduce the `SourceError` and `SinkError` marker traits which the respective errors must implement. This is a slight workaround because `PipelineError<SrcErr: Error, SnkErr: Error>` doesn't work (I tried, the type system doesn't like it), but it doesn't harm ergonomics too much.
- We add associated `Error` types on the `Sink`, `BatchSink`, and `Source` traits, with bounds on the respective `SinkError` and `SourceError` traits.
- We add a `CommonSourceError` type which encodes the common error variants implemented in the pipeline/source glue code, rather than the ones defined by the individual source/sink types.
- For convenience we add two never types: `InfallibleSourceError` and `InfallibleSinkError` and implement the `SourceError` and `SinkError` traits on them. This saves making your own useless error types when implementing sinks and sources that don't error.
- Finally we move the DuckDB and BigQuery errors to their own types, implement the traits, and wire everything up correctly.

Something remarkable with this (which even surprised me when I wrote it!) is that while this is a breaking API change, it doesn't require any change of [the typical downstream code](https://github.com/supabase/pg_replicate/blob/main/replicator/src/main.rs), as illustrated by this PR not changing anything in the `replicator` crate. Type inference takes care of it.