### PR TITLE
fix: wrap bq column names in backticks

### DIFF
--- a/pg_replicate/src/clients/bigquery.rs
+++ b/pg_replicate/src/clients/bigquery.rs
@@ -132,7 +132,9 @@ impl BigQueryClient {
     }
 
     fn column_spec(column_schema: &ColumnSchema, s: &mut String) {
+        s.push('`');
         s.push_str(&column_schema.name);
+        s.push('`');
         s.push(' ');
         let typ = Self::postgres_to_bigquery_type(&column_schema.typ);
         s.push_str(typ);
@@ -147,7 +149,9 @@ impl BigQueryClient {
         s.push_str("primary key (");
 
         for column in identity_columns {
+            s.push('`');
             s.push_str(&column.name);
+            s.push('`');
             s.push(',');
         }
 


### PR DESCRIPTION
Some keywords cannot be used as column names in a bq create table statement without wrapping them in backticks. eg the keyword `order` needs to be written out as `` `order` `` else a syntax error will be thrown.

![image](https://github.com/user-attachments/assets/0e56e3d7-a934-4122-b5f1-9a0bbb8d7464)

This PR encloses all column names in backticks when creating tables.