### PR TITLE
Pass errors to the sink trait instead of dropping the batch

### DIFF
--- a/pg_replicate/src/pipeline/data_pipeline.rs
+++ b/pg_replicate/src/pipeline/data_pipeline.rs
@@ -56,7 +56,7 @@ impl<Src: Source, Snk: Sink> DataPipeline<Src, Snk> {
             pin!(table_rows);
 
             while let Some(row) = table_rows.next().await {
-                let row = row.map_err(SourceError::TableCopyStream)?;
+                let row = row.map_err(SourceError::TableCopyStream);
                 self.sink
                     .write_table_row(row, table_schema.table_id)
                     .await?;
@@ -77,8 +77,8 @@ impl<Src: Source, Snk: Sink> DataPipeline<Src, Snk> {
         pin!(cdc_events);
 
         while let Some(cdc_event) = cdc_events.next().await {
-            let cdc_event = cdc_event.map_err(SourceError::CdcStream)?;
-            let send_status_update = if let CdcEvent::KeepAliveRequested { reply } = cdc_event {
+            let cdc_event = cdc_event.map_err(SourceError::CdcStream);
+            let send_status_update = if let Ok(CdcEvent::KeepAliveRequested { reply }) = cdc_event {
                 reply
             } else {
                 false

--- a/pg_replicate/src/pipeline/sinks/bigquery.rs
+++ b/pg_replicate/src/pipeline/sinks/bigquery.rs
@@ -9,7 +9,7 @@ use tracing::info;
 use crate::{
     clients::bigquery::BigQueryClient,
     conversions::{cdc_event::CdcEvent, table_row::TableRow, Cell},
-    pipeline::PipelineResumptionState,
+    pipeline::{PipelineResumptionState, sources::postgres::TableCopyStreamError},
     table::{ColumnSchema, TableId, TableName, TableSchema},
 };
 
@@ -159,19 +159,24 @@ impl BatchSink for BigQueryBatchSink {
 
     async fn write_table_rows(
         &mut self,
-        mut table_rows: Vec<TableRow>,
+        mut table_rows: Vec<Result<TableRow, TableCopyStreamError>>,
         table_id: TableId,
     ) -> Result<(), SinkError> {
         let table_schema = self.get_table_schema(table_id)?;
         let table_name = Self::table_name_in_bq(&table_schema.table_name);
         let table_descriptor = table_schema.into();
 
-        for table_row in &mut table_rows {
-            table_row.values.push(Cell::String("UPSERT".to_string()));
-        }
+        let new_rows = table_rows
+            .drain(..)
+            .filter_map(|row| row.ok())
+            .map(|mut row| {
+                row.values.push(Cell::String("UPSERT".to_string()));
+                row
+            })
+            .collect::<Vec<TableRow>>();
 
         self.client
-            .stream_rows(&self.dataset_id, table_name, &table_descriptor, &table_rows)
+            .stream_rows(&self.dataset_id, table_name, &table_descriptor, &new_rows)
             .await?;
 
         Ok(())

--- a/pg_replicate/src/pipeline/sinks/mod.rs
+++ b/pg_replicate/src/pipeline/sinks/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     table::{TableId, TableSchema},
 };
 
-use super::PipelineResumptionState;
+use super::{sources::SourceError, PipelineResumptionState};
 
 #[cfg(feature = "duckdb")]
 use self::duckdb::{DuckDbExecutorError, DuckDbRequest};
@@ -58,8 +58,8 @@ pub trait Sink {
         &mut self,
         table_schemas: HashMap<TableId, TableSchema>,
     ) -> Result<(), SinkError>;
-    async fn write_table_row(&mut self, row: TableRow, table_id: TableId) -> Result<(), SinkError>;
-    async fn write_cdc_event(&mut self, event: CdcEvent) -> Result<PgLsn, SinkError>;
+    async fn write_table_row(&mut self, row: Result<TableRow, SourceError>, table_id: TableId) -> Result<(), SinkError>;
+    async fn write_cdc_event(&mut self, event: Result<CdcEvent, SourceError>) -> Result<PgLsn, SinkError>;
     async fn table_copied(&mut self, table_id: TableId) -> Result<(), SinkError>;
     async fn truncate_table(&mut self, table_id: TableId) -> Result<(), SinkError>;
 }


### PR DESCRIPTION
Background: this is something I did in my branch while implementing a custom Sink. My target database had types that pg_replicate didn't handle at the time, as well as some custom types which pg_replicate can't handle at all. Debugging this efficiently was hindered by pg_replicate crashing immediately when it encountered a type it couldn't handle.

More recently the `unknown_types_to_bytes` feature has been introduced which probably renders this change unnecessary at least for decoding errors, but I want to propose it anyway; however I understand if it's rejected.

- Change the `Sink` trait to accept `Result`s in the `write_table_row`, `write_table_rows`, and `write_cdc_event` methods.
- The pipeline, instead of erroring early on encountering an error while processing an event/row batch, and dropping the events/rows, now passes the entire results directly to the trait.
- The trait implementation is then responsible for handling those errors as it wishes, including ignoring errored rows.