### PR TITLE
Error instead of panic when there's missing columns in the CDC tuple data

### DIFF
--- a/pg_replicate/src/conversions/cdc_event.rs
+++ b/pg_replicate/src/conversions/cdc_event.rs
@@ -35,6 +35,9 @@ pub enum CdcEventConversionError {
     #[error("missing tuple in delete body")]
     MissingTupleInDeleteBody,
 
+    #[error("missing column in tuple")]
+    MissingColumnInTuple,
+
     #[error("schema missing for table id {0}")]
     MissingSchema(TableId),
 
@@ -55,7 +58,7 @@ impl CdcEventConverter {
         let mut values = Vec::with_capacity(column_schemas.len());
 
         for (i, column_schema) in column_schemas.iter().enumerate() {
-            let cell = match &tuple_data[i] {
+            let cell = match &tuple_data.get(i).ok_or(CdcEventConversionError::MissingColumnInTuple)? {
                 TupleData::Null => Cell::Null,
                 TupleData::UnchangedToast => TextFormatConverter::default_value(&column_schema.typ),
                 TupleData::Binary(_) => {

--- a/pg_replicate/src/conversions/cdc_event.rs
+++ b/pg_replicate/src/conversions/cdc_event.rs
@@ -58,7 +58,10 @@ impl CdcEventConverter {
         let mut values = Vec::with_capacity(column_schemas.len());
 
         for (i, column_schema) in column_schemas.iter().enumerate() {
-            let cell = match &tuple_data.get(i).ok_or(CdcEventConversionError::MissingColumnInTuple)? {
+            let cell = match &tuple_data
+                .get(i)
+                .ok_or(CdcEventConversionError::MissingColumnInTuple)?
+            {
                 TupleData::Null => Cell::Null,
                 TupleData::UnchangedToast => TextFormatConverter::default_value(&column_schema.typ),
                 TupleData::Binary(_) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Sometimes we see this happening, which seems to indicate there's instances where there's more columns in the schema than in the tuple data. ~~We haven't quite figured out how that's possible yet.~~

This happens when a publication uses subsetted columns. From [`CREATE PUBLICATION`](https://www.postgresql.org/docs/current/sql-createpublication.html):

> When a column list is specified, only the named columns are replicated. If no column list is specified, all columns of the table are replicated through this publication, including any columns added later. It has no effect on TRUNCATE commands. See [Section 31.4](https://www.postgresql.org/docs/current/logical-replication-col-lists.html) for details about column lists.

```
thread 'main' panicked at C:\Users\julia\.cargo\git\checkouts\pg_replicate-a8efb105fe1c83a9\1afbd50\pg_replicate\src\conversions\cdc_event.rs:58:31:
index out of bounds: the len is 18 but the index is 18
```

## What is the new behavior?

Instead of a panic, this patch adds a new error type. It's not ideal, but it at least avoids a panic.

I'm not sure how to fix the underlying issue. If you have an idea (can we get the publication's column list from pg_replicate?) I can try to put a patch together.
