### PR TITLE
Support publication column lists

### DIFF
--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -149,9 +149,10 @@ impl ReplicationClient {
                         select unnest(r.prattrs)
                         from pg_publication_rel r
                         left join pg_publication p on r.prpubid = p.oid
-                        where p.pubname = '{publication}'
+                        where p.pubname = {publication}
                         and r.prrelid = {table_id}
-                    )"
+                    )",
+                    publication=quote_literal(publication),
                 ),
                 "and (
                     case (select count(*) from pub_attrs)

--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -153,12 +153,12 @@ impl ReplicationClient {
                         and r.prrelid = {table_id}
                     )"
                 ),
-                    "and (
-                        case (select count(*) from pub_attrs)
-                        when 0 then true
-                        else (a.attnum in (select * from pub_attrs))
-                        end
-                    )"
+                "and (
+                    case (select count(*) from pub_attrs)
+                    when 0 then true
+                    else (a.attnum in (select * from pub_attrs))
+                    end
+                )",
             )
         } else {
             ("".into(), "")

--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -153,17 +153,15 @@ impl ReplicationClient {
                         and r.prrelid = {table_id}
                     )"
                 ),
-                format!(
                     "and (
                         case (select count(*) from pub_attrs)
                         when 0 then true
                         else (a.attnum in (select * from pub_attrs))
                         end
                     )"
-                ),
             )
         } else {
-            ("".into(), "".into())
+            ("".into(), "")
         };
 
         let column_info_query = format!(

--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -136,13 +136,39 @@ impl ReplicationClient {
         Ok(stream)
     }
 
-    /// Returns a vector of columns of a table
+    /// Returns a vector of columns of a table, optionally filtered by a publication's column list
     pub async fn get_column_schemas(
         &self,
         table_id: TableId,
+        publication: Option<&str>,
     ) -> Result<Vec<ColumnSchema>, ReplicationClientError> {
+        let (pub_cte, pub_pred) = if let Some(publication) = publication {
+            (
+                format!(
+                    "with pub_attrs as (
+                        select unnest(r.prattrs)
+                        from pg_publication_rel r
+                        left join pg_publication p on r.prpubid = p.oid
+                        where p.pubname = '{publication}'
+                        and r.prrelid = {table_id}
+                    )"
+                ),
+                format!(
+                    "and (
+                        case (select count(*) from pub_attrs)
+                        when 0 then true
+                        else (a.attnum in (select * from pub_attrs))
+                        end
+                    )"
+                ),
+            )
+        } else {
+            ("".into(), "".into())
+        };
+
         let column_info_query = format!(
-            "select a.attname,
+            "{pub_cte}
+            select a.attname,
                 a.atttypid,
                 a.atttypmod,
                 a.attnotnull,
@@ -156,6 +182,7 @@ impl ReplicationClient {
             and not a.attisdropped
             and a.attgenerated = ''
             and a.attrelid = {table_id}
+            {pub_pred}
             order by a.attnum
             ",
         );
@@ -234,11 +261,14 @@ impl ReplicationClient {
     pub async fn get_table_schemas(
         &self,
         table_names: &[TableName],
+        publication: Option<&str>,
     ) -> Result<HashMap<TableId, TableSchema>, ReplicationClientError> {
         let mut table_schemas = HashMap::new();
 
         for table_name in table_names {
-            let table_schema = self.get_table_schema(table_name.clone()).await?;
+            let table_schema = self
+                .get_table_schema(table_name.clone(), publication)
+                .await?;
             if !table_schema.has_primary_keys() {
                 warn!(
                     "table {} with id {} will not be copied because it has no primary key",
@@ -255,12 +285,13 @@ impl ReplicationClient {
     async fn get_table_schema(
         &self,
         table_name: TableName,
+        publication: Option<&str>,
     ) -> Result<TableSchema, ReplicationClientError> {
         let table_id = self
             .get_table_id(&table_name)
             .await?
             .ok_or(ReplicationClientError::MissingTable(table_name.clone()))?;
-        let column_schemas = self.get_column_schemas(table_id).await?;
+        let column_schemas = self.get_column_schemas(table_id, publication).await?;
         Ok(TableSchema {
             table_name,
             table_id,

--- a/pg_replicate/src/pipeline/sources/postgres.rs
+++ b/pg_replicate/src/pipeline/sources/postgres.rs
@@ -68,7 +68,9 @@ impl PostgresSource {
         }
         let (table_names, publication) =
             Self::get_table_names_and_publication(&replication_client, table_names_from).await?;
-        let table_schemas = replication_client.get_table_schemas(&table_names).await?;
+        let table_schemas = replication_client
+            .get_table_schemas(&table_names, publication.as_deref())
+            .await?;
         Ok(PostgresSource {
             replication_client,
             table_schemas,

--- a/pg_replicate/src/pipeline/sources/postgres.rs
+++ b/pg_replicate/src/pipeline/sources/postgres.rs
@@ -127,7 +127,7 @@ impl Source for PostgresSource {
 
         let stream = self
             .replication_client
-            .get_table_copy_stream(table_name)
+            .get_table_copy_stream(table_name, column_schemas)
             .await
             .map_err(PostgresSourceError::ReplicationClient)?;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

#83

## What is the new behavior?

We read from `pg_publication_rel` to figure out the subset of columns that _are_ published.

## Additional context

This is done by adding a `publication: Option<&str>` argument to the `get_column_schemas` method and its callers, up to `PostgresSource::new`, and then using that when present. I've managed to do the work preserving a single query, though that did make it a bit gnarly to support both subsetted tables and full tables.