### PR TITLE
delete tenant API always returns ok

### DIFF
--- a/api/src/routes/tenants.rs
+++ b/api/src/routes/tenants.rs
@@ -193,9 +193,7 @@ pub async fn delete_tenant(
     tenant_id: Path<String>,
 ) -> Result<impl Responder, TenantError> {
     let tenant_id = tenant_id.into_inner();
-    db::tenants::delete_tenant(&pool, &tenant_id)
-        .await?
-        .ok_or(TenantError::TenantNotFound(tenant_id))?;
+    db::tenants::delete_tenant(&pool, &tenant_id).await?;
     Ok(HttpResponse::Ok().finish())
 }
 

--- a/api/tests/api/tenants.rs
+++ b/api/tests/api/tenants.rs
@@ -234,7 +234,7 @@ async fn an_existing_tenant_can_be_deleted() {
 }
 
 #[tokio::test]
-async fn a_non_existing_tenant_cant_be_deleted() {
+async fn a_non_existing_tenant_returns_ok_when_deleted() {
     // Arrange
     let app = spawn_app().await;
 
@@ -242,7 +242,7 @@ async fn a_non_existing_tenant_cant_be_deleted() {
     let response = app.delete_tenant("42").await;
 
     // Assert
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]


### PR DESCRIPTION
The delete tenant API will now return ok even when a tenant doesn't exist. This makes the API idempotent and the client code in worker doesn't have to ignore 404s.