### PR TITLE
use snake case in naming api objects for consistency

### DIFF
--- a/api/src/db/sinks.rs
+++ b/api/src/db/sinks.rs
@@ -11,6 +11,7 @@ use crate::encryption::{decrypt, encrypt, EncryptedValue, EncryptionKey};
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum SinkConfig {
+    #[serde(rename = "big_query")]
     BigQuery {
         /// BigQuery project id
         project_id: String,
@@ -298,4 +299,41 @@ pub async fn sink_exists(
     .await?;
 
     Ok(record.exists)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::sinks::SinkConfig;
+
+    #[test]
+    pub fn deserialize_settings_test() {
+        let settings = r#"{
+            "big_query": {
+                "project_id": "project-id",
+                "dataset_id": "dataset-id",
+                "service_account_key": "service-account-key"
+            }
+        }"#;
+        let actual = serde_json::from_str::<SinkConfig>(settings);
+        let expected = SinkConfig::BigQuery {
+            project_id: "project-id".to_string(),
+            dataset_id: "dataset-id".to_string(),
+            service_account_key: "service-account-key".to_string(),
+        };
+        assert!(actual.is_ok());
+        assert_eq!(expected, actual.unwrap());
+    }
+
+    #[test]
+    pub fn serialize_settings_test() {
+        let actual = SinkConfig::BigQuery {
+            project_id: "project-id".to_string(),
+            dataset_id: "dataset-id".to_string(),
+            service_account_key: "service-account-key".to_string(),
+        };
+        let expected = r#"{"big_query":{"project_id":"project-id","dataset_id":"dataset-id","service_account_key":"service-account-key"}}"#;
+        let actual = serde_json::to_string(&actual);
+        assert!(actual.is_ok());
+        assert_eq!(expected, actual.unwrap());
+    }
 }

--- a/api/src/replicator_config.rs
+++ b/api/src/replicator_config.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum SourceConfig {
+    #[serde(rename = "postgres")]
     Postgres {
         /// Host on which Postgres is running
         host: String,
@@ -48,6 +49,7 @@ impl Debug for SourceConfig {
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum SinkConfig {
+    #[serde(rename = "big_query")]
     BigQuery {
         /// BigQuery project id
         project_id: String,
@@ -96,7 +98,7 @@ mod tests {
     pub fn deserialize_settings_test() {
         let settings = r#"{
             "source": {
-                "Postgres": {
+                "postgres": {
                     "host": "localhost",
                     "port": 5432,
                     "name": "postgres",
@@ -106,7 +108,7 @@ mod tests {
                 }
             },
             "sink": {
-                "BigQuery": {
+                "big_query": {
                     "project_id": "project-id",
                     "dataset_id": "dataset-id"
                 }
@@ -159,7 +161,7 @@ mod tests {
                 max_fill_secs: 10,
             },
         };
-        let expected = r#"{"source":{"Postgres":{"host":"localhost","port":5432,"name":"postgres","username":"postgres","slot_name":"replicator_slot","publication":"replicator_publication"}},"sink":{"BigQuery":{"project_id":"project-id","dataset_id":"dataset-id"}},"batch":{"max_size":1000,"max_fill_secs":10}}"#;
+        let expected = r#"{"source":{"postgres":{"host":"localhost","port":5432,"name":"postgres","username":"postgres","slot_name":"replicator_slot","publication":"replicator_publication"}},"sink":{"big_query":{"project_id":"project-id","dataset_id":"dataset-id"}},"batch":{"max_size":1000,"max_fill_secs":10}}"#;
         let actual = serde_json::to_string(&actual);
         assert!(actual.is_ok());
         assert_eq!(expected, actual.unwrap());


### PR DESCRIPTION
All object names in the json used in api objects were named in snake case except those coming from enums. The enums have also been renamed to snake case now for consistency.