### PR TITLE
API responses now always return objects and never arrays

### DIFF
--- a/api/src/routes/images.rs
+++ b/api/src/routes/images.rs
@@ -74,6 +74,11 @@ pub struct GetImageResponse {
     is_default: bool,
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct GetImagesResponse {
+    images: Vec<GetImageResponse>,
+}
+
 #[utoipa::path(
     context_path = "/v1",
     request_body = PostImageRequest,
@@ -178,14 +183,15 @@ pub async fn delete_image(
 )]
 #[get("/images")]
 pub async fn read_all_images(pool: Data<PgPool>) -> Result<impl Responder, ImageError> {
-    let mut sources = vec![];
+    let mut images = vec![];
     for image in db::images::read_all_images(&pool).await? {
         let image = GetImageResponse {
             id: image.id,
             name: image.name,
             is_default: image.is_default,
         };
-        sources.push(image);
+        images.push(image);
     }
-    Ok(Json(sources))
+    let response = GetImagesResponse { images };
+    Ok(Json(response))
 }

--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -141,6 +141,11 @@ pub struct GetPipelineResponse {
     config: PipelineConfig,
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct GetPipelinesResponse {
+    pipelines: Vec<GetPipelineResponse>,
+}
+
 #[utoipa::path(
     context_path = "/v1",
     request_body = PostPipelineRequest,
@@ -319,7 +324,7 @@ pub async fn read_all_pipelines(
     let mut pipelines = vec![];
     for pipeline in db::pipelines::read_all_pipelines(&pool, tenant_id).await? {
         let config: PipelineConfig = serde_json::from_value(pipeline.config)?;
-        let sink = GetPipelineResponse {
+        let pipeline = GetPipelineResponse {
             id: pipeline.id,
             tenant_id: pipeline.tenant_id,
             source_id: pipeline.source_id,
@@ -330,9 +335,10 @@ pub async fn read_all_pipelines(
             publication_name: pipeline.publication_name,
             config,
         };
-        pipelines.push(sink);
+        pipelines.push(pipeline);
     }
-    Ok(Json(pipelines))
+    let response = GetPipelinesResponse { pipelines };
+    Ok(Json(response))
 }
 
 #[utoipa::path(

--- a/api/src/routes/sinks.rs
+++ b/api/src/routes/sinks.rs
@@ -93,6 +93,11 @@ pub struct GetSinkResponse {
     config: SinkConfig,
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct GetSinksResponse {
+    sinks: Vec<GetSinkResponse>,
+}
+
 #[utoipa::path(
     context_path = "/v1",
     request_body = PostSinkRequest,
@@ -229,5 +234,6 @@ pub async fn read_all_sinks(
         };
         sinks.push(sink);
     }
-    Ok(Json(sinks))
+    let response = GetSinksResponse { sinks };
+    Ok(Json(response))
 }

--- a/api/src/routes/sources.rs
+++ b/api/src/routes/sources.rs
@@ -95,6 +95,11 @@ pub struct GetSourceResponse {
     config: SourceConfig,
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct GetSourcesResponse {
+    sources: Vec<GetSourceResponse>,
+}
+
 #[utoipa::path(
     context_path = "/v1",
     request_body = PostSourceRequest,
@@ -231,5 +236,6 @@ pub async fn read_all_sources(
         };
         sources.push(source);
     }
-    Ok(Json(sources))
+    let response = GetSourcesResponse { sources };
+    Ok(Json(response))
 }

--- a/api/src/routes/sources/publications.rs
+++ b/api/src/routes/sources/publications.rs
@@ -5,7 +5,7 @@ use actix_web::{
     web::{Data, Json, Path},
     HttpRequest, HttpResponse, Responder, ResponseError,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use thiserror::Error;
 use utoipa::ToSchema;
@@ -79,6 +79,11 @@ pub struct CreatePublicationRequest {
 #[derive(Deserialize, ToSchema)]
 pub struct UpdatePublicationRequest {
     tables: Vec<Table>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct GetPublicationsResponse {
+    pub publications: Vec<Publication>,
 }
 
 #[utoipa::path(
@@ -251,6 +256,6 @@ pub async fn read_all_publications(
 
     let options = config.connect_options();
     let publications = db::publications::read_all_publications(&options).await?;
-
-    Ok(Json(publications))
+    let response = GetPublicationsResponse { publications };
+    Ok(Json(response))
 }

--- a/api/src/routes/sources/tables.rs
+++ b/api/src/routes/sources/tables.rs
@@ -4,11 +4,13 @@ use actix_web::{
     web::{Data, Json, Path},
     HttpRequest, HttpResponse, Responder, ResponseError,
 };
+use serde::Serialize;
 use sqlx::PgPool;
 use thiserror::Error;
+use utoipa::ToSchema;
 
 use crate::{
-    db::{self, sources::SourcesDbError},
+    db::{self, sources::SourcesDbError, tables::Table},
     encryption::EncryptionKey,
     routes::{extract_tenant_id, ErrorMessage, TenantIdError},
 };
@@ -37,6 +39,11 @@ impl TableError {
             e => e.to_string(),
         }
     }
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct GetTablesReponse {
+    pub tables: Vec<Table>,
 }
 
 impl ResponseError for TableError {
@@ -89,6 +96,6 @@ pub async fn read_table_names(
 
     let options = config.connect_options();
     let tables = db::tables::get_tables(&options).await?;
-
-    Ok(Json(tables))
+    let response = GetTablesReponse { tables };
+    Ok(Json(response))
 }

--- a/api/src/routes/tenants.rs
+++ b/api/src/routes/tenants.rs
@@ -81,6 +81,11 @@ pub struct GetTenantResponse {
     name: String,
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct GetTenantsResponse {
+    tenants: Vec<GetTenantResponse>,
+}
+
 #[utoipa::path(
     context_path = "/v1",
     request_body = CreateTenantRequest,
@@ -206,7 +211,7 @@ pub async fn delete_tenant(
 )]
 #[get("/tenants")]
 pub async fn read_all_tenants(pool: Data<PgPool>) -> Result<impl Responder, TenantError> {
-    let response: Vec<GetTenantResponse> = db::tenants::read_all_tenants(&pool)
+    let tenants: Vec<GetTenantResponse> = db::tenants::read_all_tenants(&pool)
         .await?
         .drain(..)
         .map(|t| GetTenantResponse {
@@ -214,5 +219,6 @@ pub async fn read_all_tenants(pool: Data<PgPool>) -> Result<impl Responder, Tena
             name: t.name,
         })
         .collect();
+    let response = GetTenantsResponse { tenants };
     Ok(Json(response))
 }

--- a/api/tests/api/images.rs
+++ b/api/tests/api/images.rs
@@ -1,7 +1,8 @@
 use reqwest::StatusCode;
 
 use crate::test_app::{
-    spawn_app, CreateImageRequest, CreateImageResponse, ImageResponse, TestApp, UpdateImageRequest,
+    spawn_app, CreateImageRequest, CreateImageResponse, ImageResponse, ImagesResponse, TestApp,
+    UpdateImageRequest,
 };
 
 pub async fn create_default_image(app: &TestApp) -> i64 {
@@ -191,11 +192,11 @@ async fn all_images_can_be_read() {
 
     // Assert
     assert!(response.status().is_success());
-    let response: Vec<ImageResponse> = response
+    let response: ImagesResponse = response
         .json()
         .await
         .expect("failed to deserialize response");
-    for image in response {
+    for image in response.images {
         if image.id == image1_id {
             assert_eq!(image.name, "some/image");
             assert!(image.is_default);

--- a/api/tests/api/pipelines.rs
+++ b/api/tests/api/pipelines.rs
@@ -8,8 +8,8 @@ use crate::{
     tenants::create_tenant,
     tenants::create_tenant_with_id_and_name,
     test_app::{
-        spawn_app, CreatePipelineRequest, CreatePipelineResponse, PipelineResponse, TestApp,
-        UpdatePipelineRequest,
+        spawn_app, CreatePipelineRequest, CreatePipelineResponse, PipelineResponse,
+        PipelinesResponse, TestApp, UpdatePipelineRequest,
     },
 };
 
@@ -439,11 +439,11 @@ async fn all_pipelines_can_be_read() {
 
     // Assert
     assert!(response.status().is_success());
-    let response: Vec<PipelineResponse> = response
+    let response: PipelinesResponse = response
         .json()
         .await
         .expect("failed to deserialize response");
-    for pipeline in response {
+    for pipeline in response.pipelines {
         if pipeline.id == pipeline1_id {
             let config = new_pipeline_config();
             assert_eq!(&pipeline.tenant_id, tenant_id);

--- a/api/tests/api/sinks.rs
+++ b/api/tests/api/sinks.rs
@@ -4,7 +4,8 @@ use reqwest::StatusCode;
 use crate::{
     tenants::create_tenant,
     test_app::{
-        spawn_app, CreateSinkRequest, CreateSinkResponse, SinkResponse, TestApp, UpdateSinkRequest,
+        spawn_app, CreateSinkRequest, CreateSinkResponse, SinkResponse, SinksResponse, TestApp,
+        UpdateSinkRequest,
     },
 };
 
@@ -225,11 +226,11 @@ async fn all_sinks_can_be_read() {
 
     // Assert
     assert!(response.status().is_success());
-    let response: Vec<SinkResponse> = response
+    let response: SinksResponse = response
         .json()
         .await
         .expect("failed to deserialize response");
-    for sink in response {
+    for sink in response.sinks {
         if sink.id == sink1_id {
             let name = new_name();
             let config = new_sink_config();

--- a/api/tests/api/sources.rs
+++ b/api/tests/api/sources.rs
@@ -4,8 +4,8 @@ use reqwest::StatusCode;
 use crate::{
     tenants::create_tenant,
     test_app::{
-        spawn_app, CreateSourceRequest, CreateSourceResponse, SourceResponse, TestApp,
-        UpdateSourceRequest,
+        spawn_app, CreateSourceRequest, CreateSourceResponse, SourceResponse, SourcesResponse,
+        TestApp, UpdateSourceRequest,
     },
 };
 
@@ -235,11 +235,11 @@ async fn all_sources_can_be_read() {
 
     // Assert
     assert!(response.status().is_success());
-    let response: Vec<SourceResponse> = response
+    let response: SourcesResponse = response
         .json()
         .await
         .expect("failed to deserialize response");
-    for source in response {
+    for source in response.sources {
         if source.id == source1_id {
             let name = new_name();
             let config = new_source_config();

--- a/api/tests/api/tenants.rs
+++ b/api/tests/api/tenants.rs
@@ -1,7 +1,7 @@
 use reqwest::StatusCode;
 
 use crate::test_app::{
-    spawn_app, CreateTenantRequest, CreateTenantResponse, TenantResponse, TestApp,
+    spawn_app, CreateTenantRequest, CreateTenantResponse, TenantResponse, TenantsResponse, TestApp,
     UpdateTenantRequest,
 };
 
@@ -267,11 +267,11 @@ async fn all_tenants_can_be_read() {
 
     // Assert
     assert!(response.status().is_success());
-    let response: Vec<TenantResponse> = response
+    let response: TenantsResponse = response
         .json()
         .await
         .expect("failed to deserialize response");
-    for tenant in response {
+    for tenant in response.tenants {
         if tenant.id == tenant1_id {
             assert_eq!(tenant.name, "Tenant1");
         } else if tenant.id == tenant2_id {

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -65,6 +65,11 @@ pub struct SourceResponse {
     pub config: SourceConfig,
 }
 
+#[derive(Deserialize)]
+pub struct SourcesResponse {
+    pub sources: Vec<SourceResponse>,
+}
+
 #[derive(Serialize)]
 pub struct CreateSinkRequest {
     pub name: String,

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -160,6 +160,11 @@ pub struct ImageResponse {
     pub is_default: bool,
 }
 
+#[derive(Deserialize)]
+pub struct ImagesResponse {
+    pub images: Vec<ImageResponse>,
+}
+
 #[derive(Serialize)]
 pub struct UpdateImageRequest {
     pub name: String,

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -40,6 +40,11 @@ pub struct TenantResponse {
     pub name: String,
 }
 
+#[derive(Deserialize)]
+pub struct TenantsResponse {
+    pub tenants: Vec<TenantResponse>,
+}
+
 #[derive(Serialize)]
 pub struct CreateSourceRequest {
     pub name: String,

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -129,6 +129,11 @@ pub struct PipelineResponse {
     pub config: PipelineConfig,
 }
 
+#[derive(Deserialize)]
+pub struct PipelinesResponse {
+    pub pipelines: Vec<PipelineResponse>,
+}
+
 #[derive(Serialize)]
 pub struct UpdatePipelineRequest {
     pub source_id: i64,

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -100,6 +100,11 @@ pub struct SinkResponse {
     pub config: SinkConfig,
 }
 
+#[derive(Deserialize)]
+pub struct SinksResponse {
+    pub sinks: Vec<SinkResponse>,
+}
+
 #[derive(Serialize)]
 pub struct CreatePipelineRequest {
     pub source_id: i64,


### PR DESCRIPTION
This is done to make it easy for the API to evolve in the future because it is easy to add another member to an object as opposed to an array whose structure is more rigid.