### PR TITLE
fix config in replicator

### DIFF
--- a/api/src/configuration.rs
+++ b/api/src/configuration.rs
@@ -229,7 +229,7 @@ pub fn get_settings<'a, T: serde::Deserialize<'a>>() -> Result<T, config::Config
             configuration_directory.join(environment_filename),
         ))
         // Add in settings from environment variables (with a prefix of APP and '__' as separator)
-        // E.g. `APP_SINK__BIGQUERY__PROJECT_ID=my-project-id would set `Settings { sink: BigQuery { project_id }}` to my-project-id
+        // E.g. `APP_SINK__BIG_QUERY__PROJECT_ID=my-project-id would set `Settings { sink: BigQuery { project_id }}` to my-project-id
         .add_source(
             config::Environment::with_prefix("APP")
                 .prefix_separator("_")

--- a/api/src/k8s_client.rs
+++ b/api/src/k8s_client.rs
@@ -329,7 +329,7 @@ impl K8sClient for HttpK8sClient {
                         }
                       },
                       {
-                        "name": "APP_SINK__BIGQUERY__SERVICE_ACCOUNT_KEY",
+                        "name": "APP_SINK__BIG_QUERY__SERVICE_ACCOUNT_KEY",
                         "valueFrom": {
                           "secretKeyRef": {
                             "name": bq_secret_name,

--- a/replicator/configuration/dev.yaml
+++ b/replicator/configuration/dev.yaml
@@ -1,5 +1,5 @@
 source:
-  Postgres:
+  postgres:
     host: "localhost"
     port: 5432
     name: "postgres"
@@ -7,6 +7,6 @@ source:
     slot_name: "replicator_slot"
     publication: "replicator_publication"
 sink:
-  BigQuery:
+  big_query:
     project_id: "project-id"
     dataset_id: "dataset-id"

--- a/replicator/src/configuration.rs
+++ b/replicator/src/configuration.rs
@@ -120,7 +120,7 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
             configuration_directory.join(environment_filename),
         ))
         // Add in settings from environment variables (with a prefix of APP and '__' as separator)
-        // E.g. `APP_SINK__BIGQUERY__PROJECT_ID=my-project-id would set `Settings { sink: BigQuery { project_id }}` to my-project-id
+        // E.g. `APP_SINK__BIG_QUERY__PROJECT_ID=my-project-id would set `Settings { sink: BigQuery { project_id }}` to my-project-id
         .add_source(
             config::Environment::with_prefix("APP")
                 .prefix_separator("_")

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod configuration;
 
-// APP_SOURCE__POSTGRES__PASSWORD and APP_SINK__BIGQUERY__PROJECT_ID environment variables must be set
+// APP_SOURCE__POSTGRES__PASSWORD and APP_SINK__BIG_QUERY__PROJECT_ID environment variables must be set
 // before running because these are sensitive values which can't be configured in the config files
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
After the recent changes in renaming the configuration to snake_case, deserializing the settings from environment variables was failing. This PR renames the environment variables to align with snake_case renaming.