### PR TITLE
removing a stale suppressed advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
 version = 2
 ignore = [
-    { id = "RUSTSEC-2024-0320", reason = "temporarily disabling" },
     { id = "RUSTSEC-2024-0370", reason = "temporarily disabling" },
     { id = "RUSTSEC-2024-0384", reason = "temporarily disabling" },
 ]


### PR DESCRIPTION
This PR will fix the [failing security audit workflow](https://github.com/supabase/pg_replicate/actions/runs/13467313041/job/37635630241). The advisory can be removed from because pg_replicate's dependency tree no longer contains `yaml-rust` crate, which this advisory was about.