### PR TITLE
Configurable max staleness

### DIFF
--- a/api/src/replicator_config.rs
+++ b/api/src/replicator_config.rs
@@ -56,6 +56,10 @@ pub enum SinkConfig {
 
         /// BigQuery dataset id
         dataset_id: String,
+
+        /// The max_staleness parameter for BigQuery: https://cloud.google.com/bigquery/docs/change-data-capture#create-max-staleness
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_staleness_mins: Option<u16>,
     },
 }
 
@@ -65,10 +69,12 @@ impl Debug for SinkConfig {
             Self::BigQuery {
                 project_id,
                 dataset_id,
+                max_staleness_mins,
             } => f
                 .debug_struct("BigQuery")
                 .field("project_id", project_id)
                 .field("dataset_id", dataset_id)
+                .field("max_staleness_mins", max_staleness_mins)
                 .finish(),
         }
     }
@@ -131,6 +137,7 @@ mod tests {
             sink: SinkConfig::BigQuery {
                 project_id: "project-id".to_string(),
                 dataset_id: "dataset-id".to_string(),
+                max_staleness_mins: None,
             },
             batch: BatchConfig {
                 max_size: 1000,
@@ -155,6 +162,7 @@ mod tests {
             sink: SinkConfig::BigQuery {
                 project_id: "project-id".to_string(),
                 dataset_id: "dataset-id".to_string(),
+                max_staleness_mins: None,
             },
             batch: BatchConfig {
                 max_size: 1000,

--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -515,6 +515,7 @@ fn create_configs(
         project_id,
         dataset_id,
         service_account_key: bigquery_service_account_key,
+        max_staleness_mins,
     } = sink_config;
 
     let secrets = Secrets {
@@ -535,6 +536,7 @@ fn create_configs(
     let sink_config = replicator_config::SinkConfig::BigQuery {
         project_id,
         dataset_id,
+        max_staleness_mins,
     };
 
     let pipeline_config: PipelineConfig = serde_json::from_value(pipeline.config)?;

--- a/api/tests/api/sinks.rs
+++ b/api/tests/api/sinks.rs
@@ -18,6 +18,7 @@ fn new_sink_config() -> SinkConfig {
         project_id: "project-id".to_string(),
         dataset_id: "dataset-id".to_string(),
         service_account_key: "service-account-key".to_string(),
+        max_staleness_mins: None,
     }
 }
 
@@ -30,6 +31,7 @@ fn updated_sink_config() -> SinkConfig {
         project_id: "project-id-updated".to_string(),
         dataset_id: "dataset-id-updated".to_string(),
         service_account_key: "service-account-key-updated".to_string(),
+        max_staleness_mins: Some(10),
     }
 }
 

--- a/pg_replicate/examples/bigquery.rs
+++ b/pg_replicate/examples/bigquery.rs
@@ -158,6 +158,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         bq_args.bq_project_id,
         bq_args.bq_dataset_id,
         &bq_args.bq_sa_key_file,
+        5,
     )
     .await?;
 

--- a/pg_replicate/src/clients/bigquery.rs
+++ b/pg_replicate/src/clients/bigquery.rs
@@ -60,11 +60,12 @@ impl BigQueryClient {
         dataset_id: &str,
         table_name: &str,
         column_schemas: &[ColumnSchema],
+        max_staleness_mins: u16,
     ) -> Result<bool, BQError> {
         if self.table_exists(dataset_id, table_name).await? {
             Ok(false)
         } else {
-            self.create_table(dataset_id, table_name, column_schemas)
+            self.create_table(dataset_id, table_name, column_schemas, max_staleness_mins)
                 .await?;
             Ok(true)
         }
@@ -189,9 +190,10 @@ impl BigQueryClient {
         dataset_id: &str,
         table_name: &str,
         column_schemas: &[ColumnSchema],
+        max_staleness_mins: u16,
     ) -> Result<(), BQError> {
         let columns_spec = Self::create_columns_spec(column_schemas);
-        let max_staleness_option = Self::max_staleness_option(5);
+        let max_staleness_option = Self::max_staleness_option(max_staleness_mins);
         let project_id = &self.project_id;
         info!("creating table {project_id}.{dataset_id}.{table_name} in bigquery");
         let query =

--- a/replicator/src/configuration.rs
+++ b/replicator/src/configuration.rs
@@ -64,6 +64,10 @@ pub enum SinkSettings {
 
         /// BigQuery service account key
         service_account_key: String,
+
+        /// The max_staleness parameter for BigQuery: https://cloud.google.com/bigquery/docs/change-data-capture#create-max-staleness
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_staleness_mins: Option<u16>,
     },
 }
 
@@ -74,11 +78,13 @@ impl Debug for SinkSettings {
                 project_id,
                 dataset_id,
                 service_account_key: _,
+                max_staleness_mins,
             } => f
                 .debug_struct("BigQuery")
                 .field("project_id", project_id)
                 .field("dataset_id", dataset_id)
                 .field("service_account_key", &"REDACTED")
+                .field("max_staleness_mins", max_staleness_mins)
                 .finish(),
         }
     }
@@ -208,6 +214,7 @@ mod tests {
                 project_id: "project-id".to_string(),
                 dataset_id: "dataset-id".to_string(),
                 service_account_key: "key".to_string(),
+                max_staleness_mins: None,
             },
             batch: BatchSettings {
                 max_size: 1000,
@@ -234,6 +241,7 @@ mod tests {
                 project_id: "project-id".to_string(),
                 dataset_id: "dataset-id".to_string(),
                 service_account_key: "key".to_string(),
+                max_staleness_mins: None,
             },
             batch: BatchSettings {
                 max_size: 1000,

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -76,10 +76,16 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         project_id,
         dataset_id,
         service_account_key,
+        max_staleness_mins,
     } = settings.sink;
 
-    let bigquery_sink =
-        BigQueryBatchSink::new_with_key(project_id, dataset_id, &service_account_key).await?;
+    let bigquery_sink = BigQueryBatchSink::new_with_key(
+        project_id,
+        dataset_id,
+        &service_account_key,
+        max_staleness_mins.unwrap_or(5),
+    )
+    .await?;
 
     let BatchSettings {
         max_size,


### PR DESCRIPTION
Adds support to configure the [max_staleness option](https://cloud.google.com/bigquery/docs/change-data-capture#create-max-staleness) for bigquery. Closes #51 