### PR TITLE
bump rustc version in dockerfiles to 1.85

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83.0-slim-bookworm AS builder
+FROM rust:1.85.0-slim-bookworm AS builder
 WORKDIR /app
 COPY . .
 ENV SQLX_OFFLINE=true

--- a/replicator/Dockerfile
+++ b/replicator/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79.0-slim-bookworm AS builder
+FROM rust:1.85.0-slim-bookworm AS builder
 WORKDIR /app
 # TODO: remove protobuf-compiler once the upstream gcp-bigquery-client remove it from its deps
 RUN apt update && apt install protobuf-compiler clang -y


### PR DESCRIPTION
Fix for failing docker builds: https://github.com/supabase/pg_replicate/actions/runs/13673977582/job/38230257153