### PR TITLE
Suppress some aggressive Rust security advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,8 @@
 [advisories]
 version = 2
 ignore = [
-    { id = "RUSTSEC-2024-0370", reason = "temporarily disabling" },
-    { id = "RUSTSEC-2024-0384", reason = "temporarily disabling" },
+    { id = "RUSTSEC-2024-0370", reason = "Disabling because it is not a real vulnerability. The crate proc-macro-error is just unmaintained." },
+    { id = "RUSTSEC-2024-0384", reason = "Disabling because it is not a real vulnerability. The crate instant is just unmaintained." },
+    { id = "RUSTSEC-2025-0012", reason = "Disabling because it is not a real vulnerability. The crate backoff is just unmaintained." },
+    { id = "RUSTSEC-2024-0436", reason = "Disabling because it is not a real vulnerability. The crate paste is just unmaintained." },
 ]


### PR DESCRIPTION
Suppresses Rust advisories about unmaintained crates. These are not actual vulnerabilities but just nudges for people to move to maintained alternatives. This helps keep the [security audit runs](https://github.com/supabase/pg_replicate/actions/runs/13731512274/job/38409320161) green.