### PR TITLE
add support for origin and truncate message types

### DIFF
--- a/pg_replicate/src/pipeline/sinks/bigquery.rs
+++ b/pg_replicate/src/pipeline/sinks/bigquery.rs
@@ -235,7 +235,11 @@ impl BatchSink for BigQueryBatchSink {
                     table_rows.push(table_row);
                 }
                 CdcEvent::Origin(_) => {}
-                CdcEvent::Truncate(_) => {}
+                CdcEvent::Truncate(_) => {
+                    // BigQuery doesn't support TRUNCATE DML statement when using the storage write API.
+                    // If you try to truncate a table that has a streaming buffer, you will get the following error:
+                    // TRUNCATE DML statement over table <tablename> would affect rows in the streaming buffer, which is not supported
+                }
                 CdcEvent::Relation(_) => {}
                 CdcEvent::KeepAliveRequested { reply: _ } => {}
                 CdcEvent::Type(_) => {}

--- a/pg_replicate/src/pipeline/sinks/bigquery.rs
+++ b/pg_replicate/src/pipeline/sinks/bigquery.rs
@@ -234,6 +234,8 @@ impl BatchSink for BigQueryBatchSink {
                         table_name_to_table_rows.entry(table_id).or_default();
                     table_rows.push(table_row);
                 }
+                CdcEvent::Origin(_) => {}
+                CdcEvent::Truncate(_) => {}
                 CdcEvent::Relation(_) => {}
                 CdcEvent::KeepAliveRequested { reply: _ } => {}
                 CdcEvent::Type(_) => {}

--- a/pg_replicate/src/pipeline/sinks/duckdb/executor.rs
+++ b/pg_replicate/src/pipeline/sinks/duckdb/executor.rs
@@ -122,6 +122,8 @@ impl DuckDbExecutor {
                             CdcEvent::Delete((table_id, table_row)) => {
                                 self.delete_row(table_id, table_row)
                             }
+                            CdcEvent::Origin(_) => Ok(()),
+                            CdcEvent::Truncate(_) => Ok(()),
                             CdcEvent::Relation(_) => Ok(()),
                             CdcEvent::KeepAliveRequested { reply: _ } => Ok(()),
                             CdcEvent::Type(_) => Ok(()),

--- a/pg_replicate/src/pipeline/sinks/duckdb/executor.rs
+++ b/pg_replicate/src/pipeline/sinks/duckdb/executor.rs
@@ -123,7 +123,15 @@ impl DuckDbExecutor {
                                 self.delete_row(table_id, table_row)
                             }
                             CdcEvent::Origin(_) => Ok(()),
-                            CdcEvent::Truncate(_) => Ok(()),
+                            CdcEvent::Truncate(truncate_body) => {
+                                let truncate_table_fn = || -> Result<(), DuckDbExecutorError> {
+                                    for table_id in truncate_body.rel_ids() {
+                                        self.truncate_table(*table_id)?;
+                                    }
+                                    Ok(())
+                                };
+                                truncate_table_fn()
+                            }
                             CdcEvent::Relation(_) => Ok(()),
                             CdcEvent::KeepAliveRequested { reply: _ } => Ok(()),
                             CdcEvent::Type(_) => Ok(()),


### PR DESCRIPTION
This PR adds support for the `origin` and `truncate` replication message types in `cdc_event` conversion code. The bigquery and duckdb sinks for now just ignore these but will be enhanced in separate PRs to handle them.

Fixes #99 