### PR TITLE
pass --all-features to cargo clippy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "rust-analyzer.cargo.features": ["duckdb", "bigquery", "stdout"]
+  "rust-analyzer.cargo.features": "all"
 }


### PR DESCRIPTION
For a better IDE experience in VSCode, this PR changes the `rust-analyzer.cargo.features` setting to `all` which passes the `--all-features` flag to cargo for any cargo command run by the IDE (e.g. cargo clippy). This prevents `cargo clippy` warnings from appearing in those projects which did not have the `duckdb`, `bigquery` or `stdout` features enabled (e.g. the `replicator` project). To reproduce the warnings, with the old setting, open a file in the `replicator` project and save it and observe the rust-analyzer in the status bar turn yellow. To view that the fix works, do the same with the new setting.