### PR TITLE
ci: explicit permission in GH actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+
+permissions:
+  contents: read
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -6,6 +6,9 @@ on: [push, pull_request]
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
     name: Rustfmt

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -36,6 +36,9 @@ jobs:
   coverage:
     name: Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     services:
       postgres:
         image: postgres:15


### PR DESCRIPTION
Nothing vulnerable, just tightening up the default permissions allowed for GITHUB_TOKEN
