### PR TITLE
fix incorrect syntax in start_replication command

### DIFF
--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -556,8 +556,8 @@ impl ReplicationClient {
         start_lsn: PgLsn,
     ) -> Result<LogicalReplicationStream, ReplicationClientError> {
         let options = format!(
-            r#"("proto_version" '1', "publication_names" {})"#,
-            quote_literal(publication),
+            r#"("proto_version" '1', "publication_names" '{}')"#,
+            quote_identifier(publication),
         );
 
         let query = format!(

--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -556,8 +556,8 @@ impl ReplicationClient {
         start_lsn: PgLsn,
     ) -> Result<LogicalReplicationStream, ReplicationClientError> {
         let options = format!(
-            r#"("proto_version" '1', "publication_names" '{}')"#,
-            quote_identifier(publication),
+            r#"("proto_version" '1', "publication_names" {})"#,
+            quote_literal(quote_identifier(publication).as_ref()),
         );
 
         let query = format!(


### PR DESCRIPTION
`pg_replicate` terminated with an error if the publication name contained capital letters.

In the `START_REPLICATION` command, `pg_replicate` was treating the publication name as a literal. It should have been treated as an identifier.

This is what the [Postgres docs](https://www.postgresql.org/docs/current/protocol-logical-replication.html#PROTOCOL-LOGICAL-REPLICATION-PARAMS) say on the format of the `publication_names` option for the `START_REPLICATION` command: 
> Comma separated list of publication names for which to subscribe (receive changes). The individual publication names are treated as standard objects names and can be quoted the same as needed. At least one publication name is required.

This means the correct format for `publication_names` is `... "publication_names" '"PublicationOne"'...` instead of the old `... "publication_names" 'PublicationOne'...`.