### PR TITLE
move the code to delete test database into a command from a test

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -49,6 +49,4 @@ tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
 utoipa = { workspace = true, features = ["actix_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["actix-web", "reqwest"] }
-
-[dev-dependencies]
 uuid = { version = "1.10.0", features = ["v4"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -29,8 +29,8 @@ pub async fn main() -> anyhow::Result<()> {
             let configuration =
                 get_settings::<'_, Settings>().expect("Failed to read configuration.");
             info!("{configuration}");
-            Application::delete_all_test_databases(configuration).await?;
-            info!("test databases deleted successfullly");
+            let num_deleted = Application::delete_all_test_databases(configuration).await?;
+            info!("{num_deleted} test databases deleted successfullly");
         } else {
             let message = "invalid command line arguments";
             error!("{message}");

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -23,6 +23,14 @@ pub async fn main() -> anyhow::Result<()> {
             info!("{configuration}");
             Application::migrate_database(configuration).await?;
             info!("database migrated successfullly");
+        } else if command == "delete-test-databases" {
+            // The cargo test command generates a lot of test databases
+            // and this command deletes them all.
+            let configuration =
+                get_settings::<'_, Settings>().expect("Failed to read configuration.");
+            info!("{configuration}");
+            Application::delete_all_test_databases(configuration).await?;
+            info!("test databases deleted successfullly");
         } else {
             let message = "invalid command line arguments";
             error!("{message}");

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -95,7 +95,7 @@ impl Application {
     pub async fn delete_all_test_databases(config: Settings) -> Result<(), anyhow::Error> {
         let mut connection = PgConnection::connect_with(&config.database.without_db()).await?;
         let databases = connection
-        .fetch_all(&*r#"select datname from pg_database where datname not in ('postgres', 'template0', 'template1');"#.to_string())
+        .fetch_all(&*r#"select datname from pg_catalog.pg_database where datname not in ('postgres', 'template0', 'template1');"#.to_string())
         .await?;
         for database in databases {
             let database_name: String = database.get("datname");


### PR DESCRIPTION
Running `cargo test` generates a lot of test databases for the api crate's end-to-end tests. These databases would accumulate after a lot of test runs and had to be cleaned up. To delete those databases we had a test which was marked ignored. If someone wanted to delete test databases, they'd comment out the `[ignore]` attribute and run `cargo run delete_test_databases`. Now we've moved the code to delete test databases as a command for the api crate. Now to delete the test databases, you'd run `cargo run -- delete-test-databasses` from the api folder. No more commenting out the `[ignore]` attribute.