### PR TITLE
add the POST /tenants-sources endpoint

### DIFF
--- a/api/src/db/mod.rs
+++ b/api/src/db/mod.rs
@@ -6,3 +6,4 @@ pub mod sinks;
 pub mod sources;
 pub mod tables;
 pub mod tenants;
+pub mod tenants_sources;

--- a/api/src/db/tenants_sources.rs
+++ b/api/src/db/tenants_sources.rs
@@ -1,0 +1,39 @@
+use aws_lc_rs::error::Unspecified;
+use sqlx::PgPool;
+use thiserror::Error;
+
+use crate::encryption::EncryptionKey;
+
+use super::{
+    sources::{create_source_txn, SourceConfig, SourcesDbError},
+    tenants::create_tenant_txn,
+};
+
+#[derive(Debug, Error)]
+pub enum TenantSourceDbError {
+    #[error("sqlx error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error("encryption error: {0}")]
+    Encryption(#[from] Unspecified),
+
+    #[error("sources error: {0}")]
+    Sources(#[from] SourcesDbError),
+}
+
+pub async fn create_tenant_and_source(
+    pool: &PgPool,
+    tenant_id: &str,
+    tenant_name: &str,
+    source_name: &str,
+    source_config: SourceConfig,
+    encryption_key: &EncryptionKey,
+) -> Result<(String, i64), TenantSourceDbError> {
+    let db_config = source_config.into_db_config(encryption_key)?;
+    let db_config = serde_json::to_value(db_config).expect("failed to serialize config");
+    let mut txn = pool.begin().await?;
+    let tenant_id = create_tenant_txn(&mut txn, tenant_id, tenant_name).await?;
+    let source_id = create_source_txn(&mut txn, &tenant_id, source_name, db_config).await?;
+    txn.commit().await?;
+    Ok((tenant_id, source_id))
+}

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod pipelines;
 pub mod sinks;
 pub mod sources;
 pub mod tenants;
+pub mod tenants_sources;
 
 #[derive(Serialize)]
 pub struct ErrorMessage {
@@ -15,7 +16,7 @@ pub struct ErrorMessage {
 }
 
 #[derive(Debug, Error)]
-enum TenantIdError {
+pub enum TenantIdError {
     #[error("tenant id missing in request")]
     TenantIdMissing,
 

--- a/api/src/routes/sources.rs
+++ b/api/src/routes/sources.rs
@@ -24,7 +24,7 @@ pub mod publications;
 pub mod tables;
 
 #[derive(Debug, Error)]
-enum SourceError {
+pub enum SourceError {
     #[error("database error: {0}")]
     DatabaseError(#[from] sqlx::Error),
 
@@ -39,7 +39,7 @@ enum SourceError {
 }
 
 impl SourceError {
-    fn to_message(&self) -> String {
+    pub fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
             SourceError::DatabaseError(_) => "internal server error".to_string(),

--- a/api/src/routes/tenants.rs
+++ b/api/src/routes/tenants.rs
@@ -34,7 +34,7 @@ pub struct PostTenantResponse {
 }
 
 #[derive(Debug, Error)]
-enum TenantError {
+pub enum TenantError {
     #[error("database error: {0}")]
     DatabaseError(#[from] sqlx::Error),
 
@@ -43,7 +43,7 @@ enum TenantError {
 }
 
 impl TenantError {
-    fn to_message(&self) -> String {
+    pub fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
             TenantError::DatabaseError(_) => "internal server error".to_string(),

--- a/api/src/routes/tenants_sources.rs
+++ b/api/src/routes/tenants_sources.rs
@@ -1,0 +1,112 @@
+use actix_web::{
+    http::{header::ContentType, StatusCode},
+    post,
+    web::{Data, Json},
+    HttpResponse, Responder, ResponseError,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use thiserror::Error;
+use utoipa::ToSchema;
+
+use crate::{
+    db::{self, sources::SourceConfig, tenants_sources::TenantSourceDbError},
+    encryption::EncryptionKey,
+};
+
+use super::ErrorMessage;
+
+#[derive(Deserialize, ToSchema)]
+pub struct CreateTenantSourceRequest {
+    #[schema(example = "abcdefghijklmnopqrst", required = true)]
+    tenant_id: String,
+
+    #[schema(example = "Tenant Name", required = true)]
+    tenant_name: String,
+
+    #[schema(example = "Source Name", required = true)]
+    source_name: String,
+
+    #[schema(required = true)]
+    source_config: SourceConfig,
+}
+
+#[derive(Debug, Error)]
+enum TenantSourceError {
+    #[error("tenants and sources db error: {0}")]
+    TenantSourceDb(#[from] TenantSourceDbError),
+}
+
+impl TenantSourceError {
+    fn to_message(&self) -> String {
+        match self {
+            TenantSourceError::TenantSourceDb(_) => "internal server error".to_string(),
+        }
+    }
+}
+
+impl ResponseError for TenantSourceError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            TenantSourceError::TenantSourceDb(e) => match e {
+                TenantSourceDbError::Sqlx(_)
+                | TenantSourceDbError::Sources(_)
+                | TenantSourceDbError::Encryption(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        let error_message = ErrorMessage {
+            error: self.to_message(),
+        };
+        let body =
+            serde_json::to_string(&error_message).expect("failed to serialize error message");
+        HttpResponse::build(self.status_code())
+            .insert_header(ContentType::json())
+            .body(body)
+    }
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct PostTenantSourceResponse {
+    tenant_id: String,
+    source_id: i64,
+}
+
+#[utoipa::path(
+    context_path = "/v1",
+    request_body = CreateTenantSourceRequest,
+    responses(
+        (status = 200, description = "Create a new tenant and a source", body = PostTenantSourceResponse),
+        (status = 500, description = "Internal server error")
+    )
+)]
+#[post("/tenants-sources")]
+pub async fn create_tenant_and_source(
+    pool: Data<PgPool>,
+    tenant_and_source: Json<CreateTenantSourceRequest>,
+    encryption_key: Data<EncryptionKey>,
+) -> Result<impl Responder, TenantSourceError> {
+    let tenant_and_source = tenant_and_source.0;
+    let CreateTenantSourceRequest {
+        tenant_id,
+        tenant_name,
+        source_name,
+        source_config,
+    } = tenant_and_source;
+    let (tenant_id, source_id) = db::tenants_sources::create_tenant_and_source(
+        &pool,
+        &tenant_id,
+        &tenant_name,
+        &source_name,
+        source_config,
+        &encryption_key,
+    )
+    .await?;
+    let response = PostTenantSourceResponse {
+        tenant_id,
+        source_id,
+    };
+    Ok(Json(response))
+}

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -44,6 +44,9 @@ use crate::{
             create_or_update_tenant, create_tenant, delete_tenant, read_all_tenants, read_tenant,
             update_tenant, CreateTenantRequest, GetTenantResponse, PostTenantResponse,
         },
+        tenants_sources::{
+            create_tenant_and_source, CreateTenantSourceRequest, PostTenantSourceResponse,
+        },
     },
 };
 
@@ -157,6 +160,7 @@ pub async fn run(
             crate::routes::sinks::update_sink,
             crate::routes::sinks::delete_sink,
             crate::routes::sinks::read_all_sinks,
+            crate::routes::tenants_sources::create_tenant_and_source,
         ),
         components(schemas(
             PostImageRequest,
@@ -177,6 +181,8 @@ pub async fn run(
             PostSinkRequest,
             PostSinkResponse,
             GetSinkResponse,
+            CreateTenantSourceRequest,
+            PostTenantSourceResponse,
         ))
     )]
     struct ApiDoc;
@@ -238,7 +244,9 @@ pub async fn run(
                     .service(read_image)
                     .service(update_image)
                     .service(delete_image)
-                    .service(read_all_images),
+                    .service(read_all_images)
+                    //tenants_sources
+                    .service(create_tenant_and_source),
             )
             .app_data(connection_pool.clone())
             .app_data(encryption_key.clone())

--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -5,4 +5,5 @@ mod pipelines;
 mod sinks;
 mod sources;
 mod tenants;
+mod tenants_sources;
 mod test_app;

--- a/api/tests/api/sources.rs
+++ b/api/tests/api/sources.rs
@@ -9,11 +9,11 @@ use crate::{
     },
 };
 
-fn new_name() -> String {
+pub fn new_name() -> String {
     "Postgres Source".to_string()
 }
 
-fn new_source_config() -> SourceConfig {
+pub fn new_source_config() -> SourceConfig {
     SourceConfig::Postgres {
         host: "localhost".to_string(),
         port: 5432,

--- a/api/tests/api/tenants_sources.rs
+++ b/api/tests/api/tenants_sources.rs
@@ -1,0 +1,52 @@
+use crate::{
+    sources::{new_name, new_source_config},
+    test_app::{
+        spawn_app, CreateTenantSourceRequest, CreateTenantSourceResponse, SourceResponse,
+        TenantResponse,
+    },
+};
+
+#[tokio::test]
+async fn tenant_and_source_can_be_created() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let tenant_source = CreateTenantSourceRequest {
+        tenant_id: "abcdefghijklmnopqrst".to_string(),
+        tenant_name: "NewTenant".to_string(),
+        source_name: new_name(),
+        source_config: new_source_config(),
+    };
+    let response = app.create_tenant_source(&tenant_source).await;
+
+    // Assert
+    assert!(response.status().is_success());
+    let response: CreateTenantSourceResponse = response
+        .json()
+        .await
+        .expect("failed to deserialize response");
+    assert_eq!(response.tenant_id, "abcdefghijklmnopqrst");
+    assert_eq!(response.source_id, 1);
+
+    let tenant_id = &response.tenant_id;
+    let source_id = response.source_id;
+
+    let response = app.read_tenant(tenant_id).await;
+    let response: TenantResponse = response
+        .json()
+        .await
+        .expect("failed to deserialize response");
+    assert_eq!(&response.id, tenant_id);
+    assert_eq!(response.name, tenant_source.tenant_name);
+
+    let response = app.read_source(tenant_id, source_id).await;
+    let response: SourceResponse = response
+        .json()
+        .await
+        .expect("failed to deserialize response");
+    assert_eq!(response.id, source_id);
+    assert_eq!(&response.tenant_id, tenant_id);
+    assert_eq!(response.name, tenant_source.source_name);
+    assert_eq!(response.config, tenant_source.source_config);
+}

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -76,6 +76,20 @@ pub struct SourcesResponse {
 }
 
 #[derive(Serialize)]
+pub struct CreateTenantSourceRequest {
+    pub tenant_id: String,
+    pub tenant_name: String,
+    pub source_name: String,
+    pub source_config: SourceConfig,
+}
+
+#[derive(Deserialize)]
+pub struct CreateTenantSourceResponse {
+    pub tenant_id: String,
+    pub source_id: i64,
+}
+
+#[derive(Serialize)]
 pub struct CreateSinkRequest {
     pub name: String,
     pub config: SinkConfig,
@@ -193,6 +207,17 @@ impl TestApp {
     pub async fn create_tenant(&self, tenant: &CreateTenantRequest) -> reqwest::Response {
         self.post_authenticated(format!("{}/v1/tenants", &self.address))
             .json(tenant)
+            .send()
+            .await
+            .expect("Failed to execute request.")
+    }
+
+    pub async fn create_tenant_source(
+        &self,
+        tenant_source: &CreateTenantSourceRequest,
+    ) -> reqwest::Response {
+        self.post_authenticated(format!("{}/v1/tenants-sources", &self.address))
+            .json(tenant_source)
             .send()
             .await
             .expect("Failed to execute request.")


### PR DESCRIPTION
This PR adds a new endpoint to create a tenant and source in a single transaction. This is needed because currently these two are created by two separate API calls to `POST /tenants` and `POST /sources` when the Enable replication button is clicked in the studio UI. The separate API calls are prone to partial failure (the first API call succeeds while the second fails), recovering from which is not easy. This new API endpoint will be used to fix that partial failure. 