### PR TITLE
add the POST /sinks-pipelines endpoint

### DIFF
--- a/api/src/db/mod.rs
+++ b/api/src/db/mod.rs
@@ -3,6 +3,7 @@ pub mod pipelines;
 pub mod publications;
 pub mod replicators;
 pub mod sinks;
+pub mod sinks_pipelines;
 pub mod sources;
 pub mod tables;
 pub mod tenants;

--- a/api/src/db/sinks_pipelines.rs
+++ b/api/src/db/sinks_pipelines.rs
@@ -1,0 +1,54 @@
+use aws_lc_rs::error::Unspecified;
+use sqlx::PgPool;
+use thiserror::Error;
+
+use crate::encryption::EncryptionKey;
+
+use super::{
+    pipelines::{create_pipeline_txn, PipelineConfig},
+    sinks::{create_sink_txn, SinkConfig, SinksDbError},
+};
+
+#[derive(Debug, Error)]
+pub enum SinkPipelineDbError {
+    #[error("sqlx error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error("encryption error: {0}")]
+    Encryption(#[from] Unspecified),
+
+    #[error("sources error: {0}")]
+    Sinks(#[from] SinksDbError),
+}
+
+#[expect(clippy::too_many_arguments)]
+pub async fn create_sink_and_pipeline(
+    pool: &PgPool,
+    tenant_id: &str,
+    source_id: i64,
+    sink_name: &str,
+    sink_config: SinkConfig,
+    image_id: i64,
+    publication_name: &str,
+    pipeline_config: PipelineConfig,
+    encryption_key: &EncryptionKey,
+) -> Result<(i64, i64), SinkPipelineDbError> {
+    let sink_config = sink_config.into_db_config(encryption_key)?;
+    let sink_config = serde_json::to_value(sink_config).expect("failed to serialize config");
+    let pipeline_config =
+        serde_json::to_value(pipeline_config).expect("failed to serialize config");
+    let mut txn = pool.begin().await?;
+    let sink_id = create_sink_txn(&mut txn, tenant_id, sink_name, sink_config).await?;
+    let pipeline_id = create_pipeline_txn(
+        &mut txn,
+        tenant_id,
+        source_id,
+        sink_id,
+        image_id,
+        publication_name,
+        pipeline_config,
+    )
+    .await?;
+    txn.commit().await?;
+    Ok((sink_id, pipeline_id))
+}

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod health_check;
 pub mod images;
 pub mod pipelines;
 pub mod sinks;
+pub mod sinks_pipelines;
 pub mod sources;
 pub mod tenants;
 pub mod tenants_sources;

--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -186,7 +186,7 @@ pub async fn create_pipeline(
         pipeline.source_id,
         pipeline.sink_id,
         image.id,
-        pipeline.publication_name,
+        &pipeline.publication_name,
         &config,
     )
     .await?;

--- a/api/src/routes/sinks.rs
+++ b/api/src/routes/sinks.rs
@@ -22,7 +22,7 @@ use crate::{
 use super::{ErrorMessage, TenantIdError};
 
 #[derive(Debug, Error)]
-enum SinkError {
+pub enum SinkError {
     #[error("database error: {0}")]
     DatabaseError(#[from] sqlx::Error),
 
@@ -37,7 +37,7 @@ enum SinkError {
 }
 
 impl SinkError {
-    fn to_message(&self) -> String {
+    pub fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
             SinkError::DatabaseError(_) => "internal server error".to_string(),

--- a/api/src/routes/sinks_pipelines.rs
+++ b/api/src/routes/sinks_pipelines.rs
@@ -1,0 +1,144 @@
+use actix_web::{
+    http::{header::ContentType, StatusCode},
+    post,
+    web::{Data, Json},
+    HttpRequest, HttpResponse, Responder, ResponseError,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use thiserror::Error;
+use utoipa::ToSchema;
+
+use crate::{
+    db::{
+        self, pipelines::PipelineConfig, sinks::SinkConfig, sinks_pipelines::SinkPipelineDbError,
+    },
+    encryption::EncryptionKey,
+    routes::extract_tenant_id,
+};
+
+use super::{sinks::SinkError, ErrorMessage, TenantIdError};
+
+#[derive(Deserialize, ToSchema)]
+pub struct CreateSinkPipelineRequest {
+    #[schema(example = "Sink Name", required = true)]
+    pub sink_name: String,
+
+    #[schema(required = true)]
+    pub sink_config: SinkConfig,
+
+    #[schema(required = true)]
+    pub source_id: i64,
+
+    #[schema(required = true)]
+    pub publication_name: String,
+
+    #[schema(required = true)]
+    pub pipeline_config: PipelineConfig,
+}
+
+#[derive(Debug, Error)]
+enum SinkPipelineError {
+    #[error("database error: {0}")]
+    DatabaseError(#[from] sqlx::Error),
+
+    #[error("no default image found")]
+    NoDefaultImageFound,
+
+    #[error("tenant id error: {0}")]
+    TenantId(#[from] TenantIdError),
+
+    #[error("sinks error: {0}")]
+    Sink(#[from] SinkError),
+
+    #[error("sinks and pipelines db error: {0}")]
+    SinkPipelineDb(#[from] SinkPipelineDbError),
+}
+
+impl SinkPipelineError {
+    fn to_message(&self) -> String {
+        match self {
+            // Do not expose internal database details in error messages
+            SinkPipelineError::DatabaseError(_) | SinkPipelineError::SinkPipelineDb(_) => {
+                "internal server error".to_string()
+            }
+            // Every other message is ok, as they do not divulge sensitive information
+            e => e.to_string(),
+        }
+    }
+}
+
+impl ResponseError for SinkPipelineError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            SinkPipelineError::Sink(e) => e.status_code(),
+            SinkPipelineError::DatabaseError(_)
+            | SinkPipelineError::NoDefaultImageFound
+            | SinkPipelineError::SinkPipelineDb(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            SinkPipelineError::TenantId(_) => StatusCode::BAD_REQUEST,
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        let error_message = ErrorMessage {
+            error: self.to_message(),
+        };
+        let body =
+            serde_json::to_string(&error_message).expect("failed to serialize error message");
+        HttpResponse::build(self.status_code())
+            .insert_header(ContentType::json())
+            .body(body)
+    }
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct PostSinkPipelineResponse {
+    sink_id: i64,
+    pipeline_id: i64,
+}
+
+#[utoipa::path(
+    context_path = "/v1",
+    request_body = CreateSinkPipelineRequest,
+    responses(
+        (status = 200, description = "Create a new sink and a pipeline", body = PostSinkPipelineResponse),
+        (status = 500, description = "Internal server error")
+    )
+)]
+#[post("/sinks-pipelines")]
+pub async fn create_sinks_and_pipelines(
+    req: HttpRequest,
+    pool: Data<PgPool>,
+    sink_and_pipeline: Json<CreateSinkPipelineRequest>,
+    encryption_key: Data<EncryptionKey>,
+) -> Result<impl Responder, SinkPipelineError> {
+    let sink_and_pipeline = sink_and_pipeline.0;
+    let CreateSinkPipelineRequest {
+        sink_name,
+        sink_config,
+        source_id,
+        publication_name,
+        pipeline_config,
+    } = sink_and_pipeline;
+    let tenant_id = extract_tenant_id(&req)?;
+    let image = db::images::read_default_image(&pool)
+        .await?
+        .ok_or(SinkPipelineError::NoDefaultImageFound)?;
+    let (sink_id, pipeline_id) = db::sinks_pipelines::create_sink_and_pipeline(
+        &pool,
+        tenant_id,
+        source_id,
+        &sink_name,
+        sink_config,
+        image.id,
+        &publication_name,
+        pipeline_config,
+        &encryption_key,
+    )
+    .await?;
+    let response = PostSinkPipelineResponse {
+        sink_id,
+        pipeline_id,
+    };
+    Ok(Json(response))
+}

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -31,6 +31,9 @@ use crate::{
             create_sink, delete_sink, read_all_sinks, read_sink, update_sink, GetSinkResponse,
             PostSinkRequest, PostSinkResponse,
         },
+        sinks_pipelines::{
+            create_sinks_and_pipelines, CreateSinkPipelineRequest, PostSinkPipelineResponse,
+        },
         sources::{
             create_source, delete_source,
             publications::{
@@ -181,6 +184,7 @@ pub async fn run(
             crate::routes::sinks::delete_sink,
             crate::routes::sinks::read_all_sinks,
             crate::routes::tenants_sources::create_tenant_and_source,
+            crate::routes::sinks_pipelines::create_sinks_and_pipelines,
         ),
         components(schemas(
             PostImageRequest,
@@ -203,6 +207,8 @@ pub async fn run(
             GetSinkResponse,
             CreateTenantSourceRequest,
             PostTenantSourceResponse,
+            CreateSinkPipelineRequest,
+            PostSinkPipelineResponse,
         ))
     )]
     struct ApiDoc;
@@ -266,7 +272,9 @@ pub async fn run(
                     .service(delete_image)
                     .service(read_all_images)
                     //tenants_sources
-                    .service(create_tenant_and_source),
+                    .service(create_tenant_and_source)
+                    // sinks-pipelines
+                    .service(create_sinks_and_pipelines),
             )
             .app_data(connection_pool.clone())
             .app_data(encryption_key.clone())

--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -3,6 +3,7 @@ mod health_check;
 mod images;
 mod pipelines;
 mod sinks;
+mod sinks_pipelines;
 mod sources;
 mod tenants;
 mod tenants_sources;

--- a/api/tests/api/pipelines.rs
+++ b/api/tests/api/pipelines.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 
-fn new_pipeline_config() -> PipelineConfig {
+pub fn new_pipeline_config() -> PipelineConfig {
     PipelineConfig {
         config: BatchConfig {
             max_size: 1000,

--- a/api/tests/api/sinks.rs
+++ b/api/tests/api/sinks.rs
@@ -9,11 +9,11 @@ use crate::{
     },
 };
 
-fn new_name() -> String {
+pub fn new_name() -> String {
     "BigQuery Sink".to_string()
 }
 
-fn new_sink_config() -> SinkConfig {
+pub fn new_sink_config() -> SinkConfig {
     SinkConfig::BigQuery {
         project_id: "project-id".to_string(),
         dataset_id: "dataset-id".to_string(),

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -90,6 +90,21 @@ pub struct CreateTenantSourceResponse {
 }
 
 #[derive(Serialize)]
+pub struct CreateSinkPipelineRequest {
+    pub sink_name: String,
+    pub sink_config: SinkConfig,
+    pub source_id: i64,
+    pub publication_name: String,
+    pub pipeline_config: PipelineConfig,
+}
+
+#[derive(Deserialize)]
+pub struct CreateSinkPipelineResponse {
+    pub sink_id: i64,
+    pub pipeline_id: i64,
+}
+
+#[derive(Serialize)]
 pub struct CreateSinkRequest {
     pub name: String,
     pub config: SinkConfig,
@@ -419,6 +434,19 @@ impl TestApp {
             .send()
             .await
             .expect("failed to execute request")
+    }
+
+    pub async fn create_sink_pipeline(
+        &self,
+        tenant_id: &str,
+        sink_pipeline: &CreateSinkPipelineRequest,
+    ) -> reqwest::Response {
+        self.post_authenticated(format!("{}/v1/sinks-pipelines", &self.address))
+            .header("tenant_id", tenant_id)
+            .json(sink_pipeline)
+            .send()
+            .await
+            .expect("Failed to execute request.")
     }
 
     pub async fn create_image(&self, image: &CreateImageRequest) -> reqwest::Response {


### PR DESCRIPTION
This PR adds a new endpoint to create a sink and pipeline in a single transaction. This is needed because currently these two are created by two separate API calls to POST /sinks and POST /pipelines when the Create destination button is clicked in the studio UI. The separate API calls are prone to partial failure (the first API call succeeds while the second fails), recovering from which is not easy. This new API endpoint will be used to fix that partial failure.