### PR TITLE
add `POST /sinks-pipelines/{sink_id}/{pipeline_id}` endpoint

### DIFF
--- a/api/src/db/sinks_pipelines.rs
+++ b/api/src/db/sinks_pipelines.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 use crate::encryption::EncryptionKey;
 
 use super::{
-    pipelines::{create_pipeline_txn, PipelineConfig},
-    sinks::{create_sink_txn, SinkConfig, SinksDbError},
+    pipelines::{create_pipeline_txn, update_pipeline_txn, PipelineConfig},
+    sinks::{create_sink_txn, update_sink_txn, SinkConfig, SinksDbError},
 };
 
 #[derive(Debug, Error)]
@@ -19,6 +19,12 @@ pub enum SinkPipelineDbError {
 
     #[error("sources error: {0}")]
     Sinks(#[from] SinksDbError),
+
+    #[error("sink with id {0} not found")]
+    SinkNotFound(i64),
+
+    #[error("pipeline with id {0} not found")]
+    PipelineNotFound(i64),
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -51,4 +57,48 @@ pub async fn create_sink_and_pipeline(
     .await?;
     txn.commit().await?;
     Ok((sink_id, pipeline_id))
+}
+
+#[expect(clippy::too_many_arguments)]
+pub async fn update_sink_and_pipeline(
+    pool: &PgPool,
+    tenant_id: &str,
+    sink_id: i64,
+    pipeline_id: i64,
+    source_id: i64,
+    sink_name: &str,
+    sink_config: SinkConfig,
+    publication_name: &str,
+    pipeline_config: PipelineConfig,
+    encryption_key: &EncryptionKey,
+) -> Result<(i64, i64), SinkPipelineDbError> {
+    let sink_config = sink_config.into_db_config(encryption_key)?;
+    let sink_config = serde_json::to_value(sink_config).expect("failed to serialize config");
+    let pipeline_config =
+        serde_json::to_value(pipeline_config).expect("failed to serialize config");
+    let mut txn = pool.begin().await?;
+    let sink_id_res = update_sink_txn(&mut txn, tenant_id, sink_name, sink_id, sink_config).await?;
+    let Some(sink_id_res) = sink_id_res else {
+        txn.rollback().await?;
+        return Err(SinkPipelineDbError::SinkNotFound(sink_id));
+    };
+    let pipeline_id_res = update_pipeline_txn(
+        &mut txn,
+        tenant_id,
+        pipeline_id,
+        source_id,
+        sink_id,
+        publication_name,
+        pipeline_config,
+    )
+    .await?;
+
+    let Some(pipeline_id_res) = pipeline_id_res else {
+        txn.rollback().await?;
+        return Err(SinkPipelineDbError::PipelineNotFound(pipeline_id));
+    };
+
+    txn.commit().await?;
+
+    Ok((sink_id_res, pipeline_id_res))
 }

--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -278,7 +278,7 @@ pub async fn update_pipeline(
         pipeline_id,
         source_id,
         sink_id,
-        publication_name,
+        &publication_name,
         config,
     )
     .await?

--- a/api/src/routes/sinks_pipelines.rs
+++ b/api/src/routes/sinks_pipelines.rs
@@ -200,7 +200,7 @@ pub async fn update_sinks_and_pipelines(
         return Err(SinkPipelineError::SinkNotFound(sink_id));
     }
 
-    let (sink_id, pipeline_id) = db::sinks_pipelines::update_sink_and_pipeline(
+    db::sinks_pipelines::update_sink_and_pipeline(
         &pool,
         tenant_id,
         sink_id,
@@ -221,10 +221,5 @@ pub async fn update_sinks_and_pipelines(
         e => e.into(),
     })?;
 
-    let response = PostSinkPipelineResponse {
-        sink_id,
-        pipeline_id,
-    };
-
-    Ok(Json(response))
+    Ok(HttpResponse::Ok().finish())
 }

--- a/api/src/routes/sinks_pipelines.rs
+++ b/api/src/routes/sinks_pipelines.rs
@@ -1,7 +1,7 @@
 use actix_web::{
     http::{header::ContentType, StatusCode},
     post,
-    web::{Data, Json},
+    web::{Data, Json, Path},
     HttpRequest, HttpResponse, Responder, ResponseError,
 };
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,10 @@ use utoipa::ToSchema;
 
 use crate::{
     db::{
-        self, pipelines::PipelineConfig, sinks::SinkConfig, sinks_pipelines::SinkPipelineDbError,
+        self,
+        pipelines::PipelineConfig,
+        sinks::{sink_exists, SinkConfig},
+        sinks_pipelines::SinkPipelineDbError,
         sources::source_exists,
     },
     encryption::EncryptionKey,
@@ -21,7 +24,7 @@ use crate::{
 use super::{sinks::SinkError, ErrorMessage, TenantIdError};
 
 #[derive(Deserialize, ToSchema)]
-pub struct CreateSinkPipelineRequest {
+pub struct PostSinkPipelineRequest {
     #[schema(example = "Sink Name", required = true)]
     pub sink_name: String,
 
@@ -52,6 +55,9 @@ enum SinkPipelineError {
     #[error("source with id {0} not found")]
     SourceNotFound(i64),
 
+    #[error("sink with id {0} not found")]
+    SinkNotFound(i64),
+
     #[error("sinks error: {0}")]
     Sink(#[from] SinkError),
 
@@ -79,9 +85,9 @@ impl ResponseError for SinkPipelineError {
             SinkPipelineError::DatabaseError(_)
             | SinkPipelineError::NoDefaultImageFound
             | SinkPipelineError::SinkPipelineDb(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            SinkPipelineError::TenantId(_) | SinkPipelineError::SourceNotFound(_) => {
-                StatusCode::BAD_REQUEST
-            }
+            SinkPipelineError::TenantId(_)
+            | SinkPipelineError::SourceNotFound(_)
+            | SinkPipelineError::SinkNotFound(_) => StatusCode::BAD_REQUEST,
         }
     }
 
@@ -105,7 +111,7 @@ pub struct PostSinkPipelineResponse {
 
 #[utoipa::path(
     context_path = "/v1",
-    request_body = CreateSinkPipelineRequest,
+    request_body = PostSinkPipelineRequest,
     responses(
         (status = 200, description = "Create a new sink and a pipeline", body = PostSinkPipelineResponse),
         (status = 500, description = "Internal server error")
@@ -115,11 +121,11 @@ pub struct PostSinkPipelineResponse {
 pub async fn create_sinks_and_pipelines(
     req: HttpRequest,
     pool: Data<PgPool>,
-    sink_and_pipeline: Json<CreateSinkPipelineRequest>,
+    sink_and_pipeline: Json<PostSinkPipelineRequest>,
     encryption_key: Data<EncryptionKey>,
 ) -> Result<impl Responder, SinkPipelineError> {
     let sink_and_pipeline = sink_and_pipeline.0;
-    let CreateSinkPipelineRequest {
+    let PostSinkPipelineRequest {
         sink_name,
         sink_config,
         source_id,
@@ -151,5 +157,63 @@ pub async fn create_sinks_and_pipelines(
         sink_id,
         pipeline_id,
     };
+    Ok(Json(response))
+}
+
+#[utoipa::path(
+    context_path = "/v1",
+    request_body = PostSinkPipelineRequest,
+    responses(
+        (status = 200, description = "Update a sink and a pipeline", body = PostSinkPipelineResponse),
+        (status = 404, description = "Pipeline or sink not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+#[post("/sinks-pipelines/{sink_id}/{pipeline_id}")]
+pub async fn update_sinks_and_pipelines(
+    req: HttpRequest,
+    pool: Data<PgPool>,
+    sink_and_pipeline_ids: Path<(i64, i64)>,
+    sink_and_pipeline: Json<PostSinkPipelineRequest>,
+    encryption_key: Data<EncryptionKey>,
+) -> Result<impl Responder, SinkPipelineError> {
+    let sink_and_pipeline = sink_and_pipeline.0;
+    let PostSinkPipelineRequest {
+        sink_name,
+        sink_config,
+        source_id,
+        publication_name,
+        pipeline_config,
+    } = sink_and_pipeline;
+    let tenant_id = extract_tenant_id(&req)?;
+    let (sink_id, pipeline_id) = sink_and_pipeline_ids.into_inner();
+
+    if !source_exists(&pool, tenant_id, source_id).await? {
+        return Err(SinkPipelineError::SourceNotFound(source_id));
+    }
+
+    if !sink_exists(&pool, tenant_id, sink_id).await? {
+        return Err(SinkPipelineError::SinkNotFound(sink_id));
+    }
+
+    let (sink_id, pipeline_id) = db::sinks_pipelines::update_sink_and_pipeline(
+        &pool,
+        tenant_id,
+        sink_id,
+        pipeline_id,
+        source_id,
+        &sink_name,
+        sink_config,
+        &publication_name,
+        pipeline_config,
+        &encryption_key,
+    )
+    .await?;
+
+    let response = PostSinkPipelineResponse {
+        sink_id,
+        pipeline_id,
+    };
+
     Ok(Json(response))
 }

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -32,7 +32,8 @@ use crate::{
             PostSinkRequest, PostSinkResponse,
         },
         sinks_pipelines::{
-            create_sinks_and_pipelines, CreateSinkPipelineRequest, PostSinkPipelineResponse,
+            create_sinks_and_pipelines, update_sinks_and_pipelines, PostSinkPipelineRequest,
+            PostSinkPipelineResponse,
         },
         sources::{
             create_source, delete_source,
@@ -185,6 +186,7 @@ pub async fn run(
             crate::routes::sinks::read_all_sinks,
             crate::routes::tenants_sources::create_tenant_and_source,
             crate::routes::sinks_pipelines::create_sinks_and_pipelines,
+            crate::routes::sinks_pipelines::update_sinks_and_pipelines,
         ),
         components(schemas(
             PostImageRequest,
@@ -207,7 +209,7 @@ pub async fn run(
             GetSinkResponse,
             CreateTenantSourceRequest,
             PostTenantSourceResponse,
-            CreateSinkPipelineRequest,
+            PostSinkPipelineRequest,
             PostSinkPipelineResponse,
         ))
     )]
@@ -274,7 +276,8 @@ pub async fn run(
                     //tenants_sources
                     .service(create_tenant_and_source)
                     // sinks-pipelines
-                    .service(create_sinks_and_pipelines),
+                    .service(create_sinks_and_pipelines)
+                    .service(update_sinks_and_pipelines),
             )
             .app_data(connection_pool.clone())
             .app_data(encryption_key.clone())

--- a/api/tests/api/pipelines.rs
+++ b/api/tests/api/pipelines.rs
@@ -22,7 +22,7 @@ pub fn new_pipeline_config() -> PipelineConfig {
     }
 }
 
-fn updated_pipeline_config() -> PipelineConfig {
+pub fn updated_pipeline_config() -> PipelineConfig {
     PipelineConfig {
         config: BatchConfig {
             max_size: 2000,

--- a/api/tests/api/sinks.rs
+++ b/api/tests/api/sinks.rs
@@ -22,11 +22,11 @@ pub fn new_sink_config() -> SinkConfig {
     }
 }
 
-fn updated_name() -> String {
+pub fn updated_name() -> String {
     "BigQuery Sink (Updated)".to_string()
 }
 
-fn updated_sink_config() -> SinkConfig {
+pub fn updated_sink_config() -> SinkConfig {
     SinkConfig::BigQuery {
         project_id: "project-id-updated".to_string(),
         dataset_id: "dataset-id-updated".to_string(),

--- a/api/tests/api/sinks_pipelines.rs
+++ b/api/tests/api/sinks_pipelines.rs
@@ -66,6 +66,38 @@ async fn sink_and_pipeline_can_be_created() {
 }
 
 #[tokio::test]
+async fn sink_and_pipeline_with_another_tenants_source_cant_be_created() {
+    // Arrange
+    let app = spawn_app().await;
+    create_default_image(&app).await;
+    let tenant1_id = &create_tenant_with_id_and_name(
+        &app,
+        "abcdefghijklmnopqrst".to_string(),
+        "tenant_1".to_string(),
+    )
+    .await;
+    let tenant2_id = &create_tenant_with_id_and_name(
+        &app,
+        "tsrqponmlkjihgfedcba".to_string(),
+        "tenant_2".to_string(),
+    )
+    .await;
+    let source2_id = create_source(&app, tenant2_id).await;
+
+    let sink_pipeline = PostSinkPipelineRequest {
+        sink_name: new_name(),
+        sink_config: new_sink_config(),
+        source_id: source2_id,
+        publication_name: "publication".to_string(),
+        pipeline_config: new_pipeline_config(),
+    };
+    let response = app.create_sink_pipeline(tenant1_id, &sink_pipeline).await;
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn an_existing_sink_and_pipeline_can_be_updated() {
     // Arrange
     let app = spawn_app().await;
@@ -138,7 +170,7 @@ async fn an_existing_sink_and_pipeline_can_be_updated() {
 }
 
 #[tokio::test]
-async fn sink_and_pipeline_with_another_tenants_source_cant_be_created() {
+async fn sink_and_pipeline_with_another_tenants_source_cant_be_updated() {
     // Arrange
     let app = spawn_app().await;
     create_default_image(&app).await;
@@ -154,16 +186,37 @@ async fn sink_and_pipeline_with_another_tenants_source_cant_be_created() {
         "tenant_2".to_string(),
     )
     .await;
-    let source2_id = create_source(&app, tenant2_id).await;
 
+    let source1_id = create_source(&app, tenant1_id).await;
     let sink_pipeline = PostSinkPipelineRequest {
         sink_name: new_name(),
         sink_config: new_sink_config(),
-        source_id: source2_id,
+        source_id: source1_id,
         publication_name: "publication".to_string(),
         pipeline_config: new_pipeline_config(),
     };
     let response = app.create_sink_pipeline(tenant1_id, &sink_pipeline).await;
+    let response: CreateSinkPipelineResponse = response
+        .json()
+        .await
+        .expect("failed to deserialize response");
+    let CreateSinkPipelineResponse {
+        sink_id,
+        pipeline_id,
+    } = response;
+
+    // Act
+    let source2_id = create_source(&app, tenant2_id).await;
+    let sink_pipeline = PostSinkPipelineRequest {
+        sink_name: updated_name(),
+        sink_config: updated_sink_config(),
+        source_id: source2_id,
+        publication_name: "updated_publication".to_string(),
+        pipeline_config: updated_pipeline_config(),
+    };
+    let response = app
+        .update_sink_pipeline(tenant1_id, sink_id, pipeline_id, &sink_pipeline)
+        .await;
 
     // Assert
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/api/tests/api/sinks_pipelines.rs
+++ b/api/tests/api/sinks_pipelines.rs
@@ -136,15 +136,6 @@ async fn an_existing_sink_and_pipeline_can_be_updated() {
 
     // Assert
     assert!(response.status().is_success());
-    let response: CreateSinkPipelineResponse = response
-        .json()
-        .await
-        .expect("failed to deserialize response");
-    assert_eq!(response.sink_id, 1);
-    assert_eq!(response.pipeline_id, 1);
-
-    let sink_id = response.sink_id;
-    let pipeline_id = response.pipeline_id;
 
     let response = app.read_sink(tenant_id, sink_id).await;
     let response: SinkResponse = response

--- a/api/tests/api/test_app.rs
+++ b/api/tests/api/test_app.rs
@@ -90,7 +90,7 @@ pub struct CreateTenantSourceResponse {
 }
 
 #[derive(Serialize)]
-pub struct CreateSinkPipelineRequest {
+pub struct PostSinkPipelineRequest {
     pub sink_name: String,
     pub sink_config: SinkConfig,
     pub source_id: i64,
@@ -439,7 +439,7 @@ impl TestApp {
     pub async fn create_sink_pipeline(
         &self,
         tenant_id: &str,
-        sink_pipeline: &CreateSinkPipelineRequest,
+        sink_pipeline: &PostSinkPipelineRequest,
     ) -> reqwest::Response {
         self.post_authenticated(format!("{}/v1/sinks-pipelines", &self.address))
             .header("tenant_id", tenant_id)
@@ -447,6 +447,24 @@ impl TestApp {
             .send()
             .await
             .expect("Failed to execute request.")
+    }
+
+    pub async fn update_sink_pipeline(
+        &self,
+        tenant_id: &str,
+        sink_id: i64,
+        pipeline_id: i64,
+        sink_pipeline: &PostSinkPipelineRequest,
+    ) -> reqwest::Response {
+        self.post_authenticated(format!(
+            "{}/v1/sinks-pipelines/{sink_id}/{pipeline_id}",
+            &self.address
+        ))
+        .header("tenant_id", tenant_id)
+        .json(sink_pipeline)
+        .send()
+        .await
+        .expect("Failed to execute request.")
     }
 
     pub async fn create_image(&self, image: &CreateImageRequest) -> reqwest::Response {


### PR DESCRIPTION
The new `POST /sinks-pipelines/{sink_id}/{pipeline_id}` endpoint allows a sink and a pipeline to be updated atomically in a transaction.