### PR TITLE
Cascade delete pipelines

### DIFF
--- a/api/migrations/20250506035802_cascade_delete_pipelines.sql
+++ b/api/migrations/20250506035802_cascade_delete_pipelines.sql
@@ -1,0 +1,13 @@
+alter table app.pipelines
+drop constraint pipelines_source_id_fkey,
+add constraint pipelines_source_id_fkey
+    foreign key (source_id)
+    references app.sources (id)
+    on delete cascade;
+
+alter table app.pipelines
+drop constraint pipelines_sink_id_fkey,
+add constraint pipelines_sink_id_fkey
+    foreign key (sink_id)
+    references app.sinks (id)
+    on delete cascade;


### PR DESCRIPTION
This PR enables cascade delete on foreign keys from `pipelines` tables to `sources` and `sinks` table to avoid making two separate calls when deleting a destination from the UI. 