### PR TITLE
Improve logging in the API and replicator crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 resolver = "2"
 
-members = ["api", "pg_replicate", "replicator"]
+members = ["api", "pg_replicate", "replicator", "telemetry"]
 
 [workspace.dependencies]
 actix-web = { version = "4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ tokio-postgres = { git = "https://github.com/imor/rust-postgres", default-featur
 tokio-postgres-rustls = { git = "https://github.com/imor/tokio-postgres-rustls", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-actix-web = { version = "0.7", default-features = false }
-tracing-bunyan-formatter = { version = "0.3", default-features = false }
-tracing-log = { version = "0.1.1", default-features = false }
+tracing-appender = { version = "0.2.3", default-features = false }
+tracing-log = { version = "0.2.0", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 utoipa = { version = "4.2.3", default-features = false }
 utoipa-swagger-ui = { version = "7.1.0", default-features = false }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -44,9 +44,13 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true, default-features = false }
 tracing-actix-web = { workspace = true, features = ["emit_event_on_error"] }
-tracing-bunyan-formatter = { workspace = true }
-tracing-log = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
+tracing-appender = { workspace = true }
+tracing-log = { workspace = true, features = ["std", "log-tracer"] }
+tracing-subscriber = { workspace = true, features = [
+    "json",
+    "env-filter",
+    "ansi",
+] }
 utoipa = { workspace = true, features = ["actix_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["actix-web", "reqwest"] }
 uuid = { version = "1.10.0", features = ["v4"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -41,16 +41,10 @@ sqlx = { workspace = true, features = [
     "migrate",
 ] }
 thiserror = { workspace = true }
+telemetry = { path = "../telemetry" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true, default-features = false }
 tracing-actix-web = { workspace = true, features = ["emit_event_on_error"] }
-tracing-appender = { workspace = true }
-tracing-log = { workspace = true, features = ["std", "log-tracer"] }
-tracing-subscriber = { workspace = true, features = [
-    "json",
-    "env-filter",
-    "ansi",
-] }
 utoipa = { workspace = true, features = ["actix_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["actix-web", "reqwest"] }
 uuid = { version = "1.10.0", features = ["v4"] }

--- a/api/src/configuration.rs
+++ b/api/src/configuration.rs
@@ -15,13 +15,6 @@ pub struct EncryptionKey {
     pub key: String,
 }
 
-impl Display for EncryptionKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "    id: {}", self.id)?;
-        writeln!(f, "    key: REDACTED")
-    }
-}
-
 const API_KEY_LENGTH_IN_BYTES: usize = 32;
 
 pub struct ApiKey {
@@ -113,16 +106,6 @@ pub struct Settings {
     pub api_key: String,
 }
 
-impl Display for Settings {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "configuration:")?;
-        writeln!(f, "  database:\n{}", self.database)?;
-        writeln!(f, "  application:\n{}", self.application)?;
-        writeln!(f, "  encryption_key:\n{}", self.encryption_key)?;
-        writeln!(f, "  api_key: REDACTED")
-    }
-}
-
 #[derive(serde::Deserialize, Clone)]
 pub struct DatabaseSettings {
     /// Host on which Postgres is running
@@ -142,17 +125,6 @@ pub struct DatabaseSettings {
 
     /// Whether to enable ssl or not
     pub require_ssl: bool,
-}
-
-impl Display for DatabaseSettings {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "    host: {}", self.host)?;
-        writeln!(f, "    port: {}", self.port)?;
-        writeln!(f, "    name: {}", self.name)?;
-        writeln!(f, "    username: {}", self.username)?;
-        writeln!(f, "    password: REDACTED")?;
-        writeln!(f, "    require_ssl: {}", self.require_ssl)
-    }
 }
 
 impl DatabaseSettings {
@@ -226,8 +198,8 @@ pub fn get_settings<'a, T: serde::Deserialize<'a>>() -> Result<T, config::Config
     settings.try_deserialize::<T>()
 }
 
-const DEV_ENV_NAME: &str = "dev";
-const PROD_ENV_NAME: &str = "prod";
+pub const DEV_ENV_NAME: &str = "dev";
+pub const PROD_ENV_NAME: &str = "prod";
 
 /// The possible runtime environment for our application.
 pub enum Environment {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6,5 +6,4 @@ pub mod k8s_client;
 pub mod replicator_config;
 pub mod routes;
 pub mod startup;
-pub mod telemetry;
 pub mod utils;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,31 +4,44 @@ use anyhow::anyhow;
 use api::{
     configuration::{get_settings, DatabaseSettings, Settings},
     startup::Application,
-    telemetry::{get_subscriber, init_subscriber},
+    telemetry::init_tracing,
 };
 use tracing::info;
 use tracing_log::log::error;
 
 #[actix_web::main]
 pub async fn main() -> anyhow::Result<()> {
-    let subscriber = get_subscriber("api".into(), "info".into(), std::io::stdout);
-    init_subscriber(subscriber);
+    let _log_flusher = init_tracing()?;
     let mut args = env::args();
 
     if args.len() == 2 {
         let command = args.nth(1).unwrap();
         if command == "migrate" {
-            let configuration =
-                get_settings::<'_, DatabaseSettings>().expect("Failed to read configuration.");
-            info!("{configuration}");
+            let configuration = get_settings::<'_, DatabaseSettings>()?;
+            let DatabaseSettings {
+                host,
+                port,
+                name,
+                username,
+                password: _,
+                require_ssl,
+            } = &configuration;
+            info!("database: host: {host}, port: {port}, dbname: {name}, username: {username}, require_ssl: {require_ssl}");
             Application::migrate_database(configuration).await?;
             info!("database migrated successfullly");
         } else if command == "delete-test-databases" {
             // The cargo test command generates a lot of test databases
             // and this command deletes them all.
-            let configuration =
-                get_settings::<'_, Settings>().expect("Failed to read configuration.");
-            info!("{configuration}");
+            let configuration = get_settings::<'_, Settings>()?;
+            let DatabaseSettings {
+                host,
+                port,
+                name,
+                username,
+                password: _,
+                require_ssl,
+            } = &configuration.database;
+            info!("database: host: {host}, port: {port}, dbname: {name}, username: {username}, require_ssl: {require_ssl}");
             let num_deleted = Application::delete_all_test_databases(configuration).await?;
             info!("{num_deleted} test databases deleted successfullly");
         } else {
@@ -37,8 +50,16 @@ pub async fn main() -> anyhow::Result<()> {
             return Err(anyhow!(message));
         }
     } else if args.len() == 1 {
-        let configuration = get_settings::<'_, Settings>().expect("Failed to read configuration.");
-        info!("{configuration}");
+        let configuration = get_settings::<'_, Settings>()?;
+        let DatabaseSettings {
+            host,
+            port,
+            name,
+            username,
+            password: _,
+            require_ssl,
+        } = &configuration.database;
+        info!("database: host: {host}, port: {port}, dbname: {name}, username: {username}, require_ssl: {require_ssl}");
         let application = Application::build(configuration.clone()).await?;
         application.run_until_stopped().await?;
     } else {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,10 +4,9 @@ use anyhow::anyhow;
 use api::{
     configuration::{get_settings, DatabaseSettings, Settings},
     startup::Application,
-    telemetry::init_tracing,
 };
-use tracing::info;
-use tracing_log::log::error;
+use telemetry::init_tracing;
+use tracing::{error, info};
 
 #[actix_web::main]
 pub async fn main() -> anyhow::Result<()> {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -10,7 +10,8 @@ use tracing::{error, info};
 
 #[actix_web::main]
 pub async fn main() -> anyhow::Result<()> {
-    let _log_flusher = init_tracing()?;
+    let app_name = env!("CARGO_BIN_NAME");
+    let _log_flusher = init_tracing(app_name)?;
     let mut args = env::args();
 
     if args.len() == 2 {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -25,7 +25,14 @@ pub async fn main() -> anyhow::Result<()> {
                 password: _,
                 require_ssl,
             } = &configuration;
-            info!("database: host: {host}, port: {port}, dbname: {name}, username: {username}, require_ssl: {require_ssl}");
+            info!(
+                host,
+                port,
+                dbname = name,
+                username,
+                require_ssl,
+                "database details",
+            );
             Application::migrate_database(configuration).await?;
             info!("database migrated successfullly");
         } else if command == "delete-test-databases" {
@@ -40,11 +47,18 @@ pub async fn main() -> anyhow::Result<()> {
                 password: _,
                 require_ssl,
             } = &configuration.database;
-            info!("database: host: {host}, port: {port}, dbname: {name}, username: {username}, require_ssl: {require_ssl}");
+            info!(
+                host,
+                port,
+                dbname = name,
+                username,
+                require_ssl,
+                "database details",
+            );
             let num_deleted = Application::delete_all_test_databases(configuration).await?;
             info!("{num_deleted} test databases deleted successfullly");
         } else {
-            let message = "invalid command line arguments";
+            let message = "invalid command: {command}";
             error!("{message}");
             return Err(anyhow!(message));
         }
@@ -58,7 +72,14 @@ pub async fn main() -> anyhow::Result<()> {
             password: _,
             require_ssl,
         } = &configuration.database;
-        info!("database: host: {host}, port: {port}, dbname: {name}, username: {username}, require_ssl: {require_ssl}");
+        info!(
+            host,
+            port,
+            dbname = name,
+            username,
+            require_ssl,
+            "database details",
+        );
         let application = Application::build(configuration.clone()).await?;
         application.run_until_stopped().await?;
     } else {

--- a/api/src/telemetry.rs
+++ b/api/src/telemetry.rs
@@ -1,37 +1,121 @@
-use tracing::subscriber::set_global_default;
-use tracing::Subscriber;
-use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
-use tracing_log::LogTracer;
-use tracing_subscriber::fmt::MakeWriter;
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+use thiserror::Error;
+use tracing::subscriber::{set_global_default, SetGlobalDefaultError};
+use tracing_appender::{
+    non_blocking::WorkerGuard,
+    rolling::{self, InitError},
+};
+use tracing_log::{log_tracer::SetLoggerError, LogTracer};
+use tracing_subscriber::{
+    fmt::{self, format::FmtSpan},
+    EnvFilter, FmtSubscriber,
+};
 
-/// Compose multiple layers into a `tracing`'s subscriber.
-///
-/// # Implementation Notes
-///
-/// We are using `impl Subscriber` as return type to avoid having to spell out the actual
-/// type of the returned subscriber, which is indeed quite complex.
-pub fn get_subscriber<Sink>(
-    name: String,
-    env_filter: String,
-    sink: Sink,
-) -> impl Subscriber + Sync + Send
-where
-    Sink: for<'a> MakeWriter<'a> + Send + Sync + 'static,
-{
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(env_filter));
-    let formatting_layer = BunyanFormattingLayer::new(name, sink);
-    Registry::default()
-        .with(env_filter)
-        .with(JsonStorageLayer)
-        .with(formatting_layer)
+use crate::configuration::{DEV_ENV_NAME, PROD_ENV_NAME};
+
+#[derive(Debug, Error)]
+pub enum TracingError {
+    #[error("failed to build rolling file appender: {0}")]
+    InitAppender(#[from] InitError),
+
+    #[error("failed to init log tracer: {0}")]
+    InitLogTracer(#[from] SetLoggerError),
+
+    #[error("failed to set global default subscriber: {0}")]
+    SetGlobalDefault(#[from] SetGlobalDefaultError),
 }
 
-/// Register a subscriber as global default to process span data.
-///
-/// It should only be called once!
-pub fn init_subscriber(subscriber: impl Subscriber + Sync + Send) {
-    LogTracer::init().expect("Failed to set logger");
-    set_global_default(subscriber).expect("Failed to set subscriber");
+#[must_use]
+pub enum LogFlusher {
+    Flusher(WorkerGuard),
+    NullFlusher,
+}
+
+/// Initializes tracing for the application.
+pub fn init_tracing() -> Result<LogFlusher, TracingError> {
+    // Initialize the log tracer to capture logs from the `log` crate
+    // and send them to the `tracing` subscriber. This captures logs
+    // from libraries that use the `log` crate.
+    LogTracer::init()?;
+
+    let is_prod =
+        std::env::var("APP_ENVIRONMENT").unwrap_or_else(|_| DEV_ENV_NAME.into()) == PROD_ENV_NAME;
+
+    // Set the default log level to `info` if not specified in the RUST_LOG environment variable.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
+
+    let log_flusher = if is_prod {
+        configure_prod_tracing(filter)?
+    } else {
+        configure_dev_tracing(filter)?
+    };
+
+    // Return the log flusher to ensure logs are flushed before the application exits
+    // without this the logs in memory may not be flushed to the file
+    Ok(log_flusher)
+}
+
+fn configure_prod_tracing(filter: EnvFilter) -> Result<LogFlusher, TracingError> {
+    let app_name = env!("CARGO_CRATE_NAME");
+    let filename_suffix = "log";
+    let log_dir = "logs";
+    let file_appender = rolling::Builder::new()
+        .filename_prefix(app_name)
+        .filename_suffix(filename_suffix)
+        // rotate the log file every day
+        .rotation(rolling::Rotation::DAILY)
+        // keep a maximum of 5 log files
+        .max_log_files(5)
+        .build(log_dir)?;
+
+    // Create a non-blocking appender to avoid blocking the logging thread
+    // when writing to the file. This is important for performance.
+    let (file_appender, guard) = tracing_appender::non_blocking(file_appender);
+
+    let format = fmt::format()
+        .with_level(true)
+        // ANSI colors are only for terminal output
+        .with_ansi(false)
+        // Disable target to reduce noise in the logs
+        .with_target(false);
+
+    let subscriber = FmtSubscriber::builder()
+        .event_format(format)
+        .with_writer(file_appender)
+        .json()
+        // emit a log event when a span is closed
+        // since a request is a span, this will emit a log event
+        // when the request is completed
+        .with_span_events(FmtSpan::CLOSE)
+        .with_env_filter(filter)
+        .finish();
+
+    set_global_default(subscriber)?;
+    Ok(LogFlusher::Flusher(guard))
+}
+
+fn configure_dev_tracing(filter: EnvFilter) -> Result<LogFlusher, TracingError> {
+    let format = fmt::format()
+        // Emit the log level in the log output
+        .with_level(true)
+        // Enable ANSI colors for terminal output
+        .with_ansi(true)
+        // Make it pretty
+        .pretty()
+        // Disable line number, file, and target in the log output
+        // to reduce noise in the logs
+        .with_line_number(false)
+        .with_file(false)
+        .with_target(false);
+
+    let subscriber = FmtSubscriber::builder()
+        .event_format(format)
+        // emit a log event when a span is closed
+        // since a request is a span, this will emit a log event
+        // when the request is completed
+        .with_span_events(FmtSpan::CLOSE)
+        .with_env_filter(filter)
+        .finish();
+
+    set_global_default(subscriber)?;
+    Ok(LogFlusher::NullFlusher)
 }

--- a/replicator/Cargo.toml
+++ b/replicator/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = { workspace = true, features = ["std"] }
 config = { workspace = true, features = ["yaml"] }
 pg_replicate = { path = "../pg_replicate", features = ["bigquery"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 secrecy = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
 rustls-pemfile = { workspace = true, features = ["std"] }
+telemetry = { path = "../telemetry" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true, default-features = true }
-tracing-subscriber = { workspace = true, default-features = true, features = [
-    "env-filter",
-] }

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, io::BufReader, time::Duration, vec};
+use std::{io::BufReader, time::Duration, vec};
 
 use configuration::{get_configuration, BatchSettings, SinkSettings, SourceSettings, TlsSettings};
 use pg_replicate::{
@@ -10,49 +10,53 @@ use pg_replicate::{
     },
     SslMode,
 };
-use tracing::{error, info};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use telemetry::init_tracing;
+use tracing::info;
 
 mod configuration;
 
 // APP_SOURCE__POSTGRES__PASSWORD and APP_SINK__BIG_QUERY__PROJECT_ID environment variables must be set
 // before running because these are sensitive values which can't be configured in the config files
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    if let Err(e) = main_impl().await {
-        error!("{e}");
-    }
-
-    Ok(())
-}
-
-fn init_tracing() {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "replicator=info".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-}
-
-fn set_log_level() {
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
-    }
-}
-
-async fn main_impl() -> Result<(), Box<dyn Error>> {
-    set_log_level();
-    init_tracing();
-
+async fn main() -> anyhow::Result<()> {
+    let _log_flusher = init_tracing()?;
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("failed to install default crypto provider");
 
     let settings = get_configuration()?;
 
-    info!("settings: {settings:#?}");
+    let SourceSettings::Postgres {
+        host,
+        port,
+        name,
+        username,
+        password: _,
+        slot_name,
+        publication,
+    } = &settings.source;
+    info!("source settings: host: {host}, port: {port}, dbname: {name}, username: {username}, slot_name: {slot_name}, publication: {publication}");
+
+    let SinkSettings::BigQuery {
+        project_id,
+        dataset_id,
+        service_account_key: _,
+        max_staleness_mins,
+    } = &settings.sink;
+
+    info!("sink settings: project_id: {project_id}, dataset_id: {dataset_id}, max_staleness_mins: {max_staleness_mins:?}");
+
+    let BatchSettings {
+        max_size,
+        max_fill_secs,
+    } = &settings.batch;
+    info!("batch settings: max_size: {max_size}, max_fill_secs: {max_fill_secs}");
+
+    let TlsSettings {
+        trusted_root_certs: _,
+        enabled,
+    } = &settings.tls;
+    info!("tls settings: tls_enabled: {enabled}");
 
     settings.tls.validate()?;
 

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -19,7 +19,8 @@ mod configuration;
 // before running because these are sensitive values which can't be configured in the config files
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let _log_flusher = init_tracing()?;
+    let app_name = env!("CARGO_BIN_NAME");
+    let _log_flusher = init_tracing(app_name)?;
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("failed to install default crypto provider");

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -35,7 +35,15 @@ async fn main() -> anyhow::Result<()> {
         slot_name,
         publication,
     } = &settings.source;
-    info!("source settings: host: {host}, port: {port}, dbname: {name}, username: {username}, slot_name: {slot_name}, publication: {publication}");
+    info!(
+        host,
+        port,
+        dbname = name,
+        username,
+        slot_name,
+        publication,
+        "source settings"
+    );
 
     let SinkSettings::BigQuery {
         project_id,
@@ -44,19 +52,19 @@ async fn main() -> anyhow::Result<()> {
         max_staleness_mins,
     } = &settings.sink;
 
-    info!("sink settings: project_id: {project_id}, dataset_id: {dataset_id}, max_staleness_mins: {max_staleness_mins:?}");
+    info!(project_id, dataset_id, max_staleness_mins, "sink settings");
 
     let BatchSettings {
         max_size,
         max_fill_secs,
     } = &settings.batch;
-    info!("batch settings: max_size: {max_size}, max_fill_secs: {max_fill_secs}");
+    info!(max_size, max_fill_secs, "batch settings");
 
     let TlsSettings {
         trusted_root_certs: _,
         enabled,
     } = &settings.tls;
-    info!("tls settings: tls_enabled: {enabled}");
+    info!(tls_enabled = enabled, "tls settings");
 
     settings.tls.validate()?;
 

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "telemetry"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+thiserror = { workspace = true }
+tracing = { workspace = true, default-features = true }
+tracing-appender = { workspace = true }
+tracing-log = { workspace = true, features = ["std", "log-tracer"] }
+tracing-subscriber = { workspace = true, default-features = true, features = [
+    "json",
+    "env-filter",
+    "ansi",
+] }

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -10,7 +10,8 @@ use tracing_subscriber::{
     EnvFilter, FmtSubscriber,
 };
 
-use crate::configuration::{DEV_ENV_NAME, PROD_ENV_NAME};
+const DEV_ENV_NAME: &str = "dev";
+const PROD_ENV_NAME: &str = "prod";
 
 #[derive(Debug, Error)]
 pub enum TracingError {

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -32,7 +32,7 @@ pub enum LogFlusher {
 }
 
 /// Initializes tracing for the application.
-pub fn init_tracing() -> Result<LogFlusher, TracingError> {
+pub fn init_tracing(app_name: &str) -> Result<LogFlusher, TracingError> {
     // Initialize the log tracer to capture logs from the `log` crate
     // and send them to the `tracing` subscriber. This captures logs
     // from libraries that use the `log` crate.
@@ -45,7 +45,7 @@ pub fn init_tracing() -> Result<LogFlusher, TracingError> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
 
     let log_flusher = if is_prod {
-        configure_prod_tracing(filter)?
+        configure_prod_tracing(filter, app_name)?
     } else {
         configure_dev_tracing(filter)?
     };
@@ -55,8 +55,7 @@ pub fn init_tracing() -> Result<LogFlusher, TracingError> {
     Ok(log_flusher)
 }
 
-fn configure_prod_tracing(filter: EnvFilter) -> Result<LogFlusher, TracingError> {
-    let app_name = env!("CARGO_CRATE_NAME");
+fn configure_prod_tracing(filter: EnvFilter, app_name: &str) -> Result<LogFlusher, TracingError> {
     let filename_suffix = "log";
     let log_dir = "logs";
     let file_appender = rolling::Builder::new()


### PR DESCRIPTION
In a dev environment:

* Logs are printed on stdout
* Logs are pretty printed with colors enabled

In a prod environment:

* Logs are sent to a file in the logs folder
* Writing to the file is done on a background process for performance
* Logs are written in structured json format
* Logs are rotated daily to avoid filling up the disk
* Maximum 5 log files are kept, older are rotated out

Some multi-line logs lines have been flattened into a single file as they didn't play well with the json output. The older bunyan format logger has been removed. Telemetry related code has been factored out into its own separate crate named `telemetry` and reused from both the `api` and the `replicator` crates. We are also now emitting more structured fields wherever possible. E.g. database details are logged not as a string but passed as separate fields to the `tracing::info!` macro.

In future we'd like to:

* Make the hardcoded values for log rotation configurable.
* Rotate log files based on their size instead of daily to avoid filling the disk.
* Handle edge cases in which crashes could leave the in-buffer logs not being flushed.