### PR TITLE
emit project field in the root span in replicator

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -11,7 +11,12 @@ use tracing::{error, info};
 #[actix_web::main]
 pub async fn main() -> anyhow::Result<()> {
     let app_name = env!("CARGO_BIN_NAME");
-    let _log_flusher = init_tracing(app_name)?;
+    // We pass emit_on_span_close = true to emit logs on span close
+    // for the api because it is a web server and we need to emit logs
+    // for every closing request. This is a bit of a hack, but it works
+    // for now. Ideally the tracing middleware should emit a log on
+    // request end, but it doesn't do that yet.
+    let _log_flusher = init_tracing(app_name, true)?;
     let mut args = env::args();
 
     if args.len() == 2 {

--- a/api/src/replicator_config.rs
+++ b/api/src/replicator_config.rs
@@ -104,6 +104,7 @@ pub struct Config {
     pub sink: SinkConfig,
     pub batch: BatchConfig,
     pub tls: TlsConfig,
+    pub project: String,
 }
 
 #[cfg(test)]
@@ -161,6 +162,7 @@ mod tests {
                 trusted_root_certs: "".to_string(),
                 enabled: false,
             },
+            project: "abcdefghijklmnopqrst".to_string(),
         };
         assert!(actual.is_ok());
         assert_eq!(expected, actual.unwrap());
@@ -190,8 +192,9 @@ mod tests {
                 trusted_root_certs: "".to_string(),
                 enabled: false,
             },
+            project: "abcdefghijklmnopqrst".to_string(),
         };
-        let expected = r#"{"source":{"postgres":{"host":"localhost","port":5432,"name":"postgres","username":"postgres","slot_name":"replicator_slot","publication":"replicator_publication"}},"sink":{"big_query":{"project_id":"project-id","dataset_id":"dataset-id"}},"batch":{"max_size":1000,"max_fill_secs":10},"tls":{"trusted_root_certs":"","enabled":false}}"#;
+        let expected = r#"{"source":{"postgres":{"host":"localhost","port":5432,"name":"postgres","username":"postgres","slot_name":"replicator_slot","publication":"replicator_publication"}},"sink":{"big_query":{"project_id":"project-id","dataset_id":"dataset-id"}},"batch":{"max_size":1000,"max_fill_secs":10},"tls":{"trusted_root_certs":"","enabled":false},"project":"abcdefghijklmnopqrst"}"#;
         let actual = serde_json::to_string(&actual);
         assert!(actual.is_ok());
         assert_eq!(expected, actual.unwrap());

--- a/api/src/replicator_config.rs
+++ b/api/src/replicator_config.rs
@@ -137,7 +137,8 @@ mod tests {
             "tls": {
                 "trusted_root_certs": "",
                 "enabled": false
-            }
+            },
+            "project": "abcdefghijklmnopqrst"
         }"#;
         let actual = serde_json::from_str::<Config>(settings);
         let expected = Config {

--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -366,8 +366,14 @@ pub async fn start_pipeline(
     let (pipeline, replicator, image, source, sink) =
         read_data(&pool, tenant_id, pipeline_id, &encryption_key).await?;
 
-    let (secrets, config) =
-        create_configs(&k8s_client, source.config, sink.config, pipeline).await?;
+    let (secrets, config) = create_configs(
+        &k8s_client,
+        source.config,
+        sink.config,
+        pipeline,
+        tenant_id.to_string(),
+    )
+    .await?;
     let prefix = create_prefix(tenant_id, replicator.id);
 
     create_or_update_secrets(&k8s_client, &prefix, secrets).await?;
@@ -507,6 +513,7 @@ async fn create_configs(
     source_config: SourceConfig,
     sink_config: SinkConfig,
     pipeline: Pipeline,
+    project: String,
 ) -> Result<(Secrets, replicator_config::Config), PipelineError> {
     let SourceConfig::Postgres {
         host,
@@ -572,6 +579,7 @@ async fn create_configs(
         sink: sink_config,
         batch: batch_config,
         tls: tls_config,
+        project,
     };
 
     Ok((secrets, config))

--- a/pg_replicate/src/pipeline/sinks/bigquery.rs
+++ b/pg_replicate/src/pipeline/sinks/bigquery.rs
@@ -79,6 +79,7 @@ impl BigQueryBatchSink {
         })
     }
 
+    #[expect(clippy::result_large_err)]
     fn get_table_schema(&self, table_id: TableId) -> Result<&TableSchema, BigQuerySinkError> {
         self.table_schemas
             .as_ref()

--- a/replicator/configuration/base.yaml
+++ b/replicator/configuration/base.yaml
@@ -4,3 +4,4 @@ batch:
 tls:
   trusted_root_certs: ""
   enabled: false
+project: "abcdefghijklmnopqrst"

--- a/replicator/src/configuration.rs
+++ b/replicator/src/configuration.rs
@@ -241,7 +241,8 @@ mod tests {
             "tls": {
                 "trusted_root_certs": "",
                 "enabled": false
-            }
+            },
+            "project": "abcdefghijklmnopqrst"
         }"#;
         let actual = serde_json::from_str::<Settings>(settings);
         let expected = Settings {

--- a/replicator/src/configuration.rs
+++ b/replicator/src/configuration.rs
@@ -140,6 +140,7 @@ pub struct Settings {
     pub sink: SinkSettings,
     pub batch: BatchSettings,
     pub tls: TlsSettings,
+    pub project: String,
 }
 
 pub fn get_configuration() -> Result<Settings, config::ConfigError> {
@@ -267,6 +268,7 @@ mod tests {
                 trusted_root_certs: String::new(),
                 enabled: false,
             },
+            project: "abcdefghijklmnopqrst".to_string(),
         };
         assert!(actual.is_ok());
         assert_eq!(expected, actual.unwrap());
@@ -298,8 +300,9 @@ mod tests {
                 trusted_root_certs: String::new(),
                 enabled: false,
             },
+            project: "abcdefghijklmnopqrst".to_string(),
         };
-        let expected = r#"{"source":{"postgres":{"host":"localhost","port":5432,"name":"postgres","username":"postgres","password":"postgres","slot_name":"replicator_slot","publication":"replicator_publication"}},"sink":{"big_query":{"project_id":"project-id","dataset_id":"dataset-id","service_account_key":"key"}},"batch":{"max_size":1000,"max_fill_secs":10},"tls":{"trusted_root_certs":"","enabled":false}}"#;
+        let expected = r#"{"source":{"postgres":{"host":"localhost","port":5432,"name":"postgres","username":"postgres","password":"postgres","slot_name":"replicator_slot","publication":"replicator_publication"}},"sink":{"big_query":{"project_id":"project-id","dataset_id":"dataset-id","service_account_key":"key"}},"batch":{"max_size":1000,"max_fill_secs":10},"tls":{"trusted_root_certs":"","enabled":false},"project":"abcdefghijklmnopqrst"}"#;
         let actual = serde_json::to_string(&actual);
         assert!(actual.is_ok());
         assert_eq!(expected, actual.unwrap());

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -27,11 +27,11 @@ async fn main() -> anyhow::Result<()> {
     // for every closing span.
     let _log_flusher = init_tracing(app_name, false)?;
     let settings = get_configuration()?;
-    main_impl(settings).await
+    start_replication(settings).await
 }
 
-#[instrument(name = "main", skip(settings), fields(project = settings.project))]
-async fn main_impl(settings: Settings) -> anyhow::Result<()> {
+#[instrument(name = "replication", skip(settings), fields(project = settings.project))]
+async fn start_replication(settings: Settings) -> anyhow::Result<()> {
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("failed to install default crypto provider");

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -22,7 +22,10 @@ mod configuration;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let app_name = env!("CARGO_BIN_NAME");
-    let _log_flusher = init_tracing(app_name)?;
+    // We pass emit_on_span_close = false to avoid emitting logs on span close
+    // for replicator because it is not a web server and we don't need to emit logs
+    // for every closing span.
+    let _log_flusher = init_tracing(app_name, false)?;
     let settings = get_configuration()?;
     main_impl(settings).await
 }


### PR DESCRIPTION
This PR emits a field named `project` in the replicator's root span called `replication`. The `project` field can be used to filter for a specific project in logflare logs.

It also emits a log on span close only for the `api` crate and disables it for the `replicator` crate. Emitting on close for the `api` crate is required to log on request close. This is a bit of a hack but works for now. In future we'd like the tracing middleware to emit these logs because currently the middleware doesn't support it.
